### PR TITLE
removed version for pylint-quotes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ REQUIRED_PACKAGES = [
     'parameterized==0.6.1',
     'ruamel.yaml==0.15.37',
     'pylint==1.9.4',
-    'pylint-quotes==0.2.1',
+    'pylint-quotes',
     'SQLAlchemy==1.2.16',
     'sqlalchemy-migrate==0.11.0'
 ]


### PR DESCRIPTION
Setting version 0.2.0 for pylint-quotes proves somewhat problematic.  Version 0.2.0 requires python >3.4 per PyPi.  The setup script fails out if major version 3 is detected.

I recommend removing the version of pylint-quotes unless it is specifically needed.  In which case, I would set the required version of Python to 3.x
