### PR TITLE
Updated resource_name in IAM violation to reflect the resource name instead of policy name

### DIFF
--- a/google/cloud/forseti/scanner/scanners/iam_rules_scanner.py
+++ b/google/cloud/forseti/scanner/scanners/iam_rules_scanner.py
@@ -150,7 +150,8 @@ class IamPolicyScanner(base_scanner.BaseScanner):
                 }
 
                 yield {
-                    'resource_name': member,
+                    'resource_name': '%/%'.format(violation.resource_type,
+                                                  violation.resource_id),
                     'resource_id': violation.resource_id,
                     'resource_type': violation.resource_type,
                     'full_name': violation.full_name,


### PR DESCRIPTION
Example resource name after the update: bucket/ejg-forseti-target-open

Resolves #2669 