### PR TITLE
Close iterator for sqlalchemy query

### DIFF
--- a/google/cloud/forseti/scanner/scanners/bucket_rules_scanner.py
+++ b/google/cloud/forseti/scanner/scanners/bucket_rules_scanner.py
@@ -121,8 +121,9 @@ class BucketsAclScanner(base_scanner.BaseScanner):
         scoped_session, data_access = model_manager.get(self.model_name)
         with scoped_session as session:
             bucket_acls = []
-
-            for gcs_policy in data_access.scanner_iter(session, 'gcs_policy'):
+            gcs_policies = [policy for policy in
+                            data_access.scanner_iter(session, 'gcs_policy')]
+            for gcs_policy in gcs_policies:
                 bucket = gcs_policy.parent
                 project_id = bucket.parent.name
                 acls = json.loads(gcs_policy.data)


### PR DESCRIPTION
References #2763

Close iterator for sqlalchemy query to prevent "Commands out of sync; you can't run this command now" error when running BucketsAclScanner.

Merge into fs-future Python 3 branch.