### PR TITLE
Update jekyll_build.sh

### DIFF
--- a/travis/jekyll_build.sh
+++ b/travis/jekyll_build.sh
@@ -27,6 +27,7 @@ JEKYLL_GITHUB_TOKEN=$JGT bundle exec jekyll build >> build.log 2 >&1
 kill %1
 
 bundle exec htmlproofer --check-img-http --check-html \
+--internal-domains 'forsetisecurity.org' \
 --check-favicon --report-missing-names --report-script-embeds \
 --url-ignore '/GoogleCloudPlatform/forseti-security/edit/,/maxcdn.bootstrapcdn.com/,/d3js.org/' \
 --file-ignore '/develop/reference/' './_www/www/'


### PR DESCRIPTION
Treat forsetiseccurity.org as internal domain.

Fixes #2868
