### PR TITLE
Add in traceback if there is an error during scanner run

### DIFF
--- a/google/cloud/forseti/scanner/scanner.py
+++ b/google/cloud/forseti/scanner/scanner.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 """GCP Resource scanner."""
 
+import traceback
+
 from google.cloud.forseti.common.util import logger
 from google.cloud.forseti.common.util.index_state import IndexState
 from google.cloud.forseti.scanner import scanner_builder
@@ -121,6 +123,7 @@ def run(model_name=None,
                 log_message = 'Error running scanner: {}'.format(
                     scanner.__class__.__name__)
                 progress_queue.put(log_message)
+                progress_queue.put(traceback.format_exc())
                 LOGGER.exception(log_message)
                 failed.append(scanner.__class__.__name__)
             else:

--- a/google/cloud/forseti/scanner/scanner.py
+++ b/google/cloud/forseti/scanner/scanner.py
@@ -120,10 +120,9 @@ def run(model_name=None,
                 progress_queue.put('Running {}...'.format(
                     scanner.__class__.__name__))
             except Exception:  # pylint: disable=broad-except
-                log_message = 'Error running scanner: {}'.format(
-                    scanner.__class__.__name__)
-                progress_queue.put('{}: \'{}\''.format(
-                    log_message, traceback.format_exc()))
+                log_message = 'Error running scanner: {}: \'{}\''.format(
+                    scanner.__class__.__name__, traceback.format_exc())
+                progress_queue.put(log_message)
                 LOGGER.exception(log_message)
                 failed.append(scanner.__class__.__name__)
             else:

--- a/google/cloud/forseti/scanner/scanner.py
+++ b/google/cloud/forseti/scanner/scanner.py
@@ -122,8 +122,8 @@ def run(model_name=None,
             except Exception:  # pylint: disable=broad-except
                 log_message = 'Error running scanner: {}'.format(
                     scanner.__class__.__name__)
-                progress_queue.put(log_message)
-                progress_queue.put(traceback.format_exc())
+                progress_queue.put('{}: \'{}\''.format(
+                    log_message, traceback.format_exc()))
                 LOGGER.exception(log_message)
                 failed.append(scanner.__class__.__name__)
             else:


### PR DESCRIPTION
References Issue #2800 

Add in traceback if there is an error during notification.

Example output:

```
$ forseti scanner run
{
  "serverMessage": "Scanner Index ID: 1559235893675909 is created"
}
{
  "serverMessage": "Error running scanner: IamPolicyScanner"
}
{
  "serverMessage": "Traceback (most recent call last):\n  File \"/usr/local/lib/python3.6/dist-packages/forseti_security-2.16.0-py3.6.egg/google/cloud/forseti/scanner/scanner.py\", line 119, in run\n    scanner.run()\n  File \"/usr/local/lib/python3.6/dist-packages/forseti_security-2.16.0-py3.6.egg/google/cloud/forseti/scanner/scanners/iam_rules_scanner.py\", line 239, in run\n    self._output_results(all_violations)\n  File \"/usr/local/lib/python3.6/dist-packages/forseti_security-2.16.0-py3.6.egg/google/cloud/forseti/scanner/scanners/iam_rules_scanner.py\", line 171, in _output_results\n    all_violations = self._flatten_violations(all_violationss)\nNameError: name 'all_violationss' is not defined\n"
}
{
  "serverMessage": "Running KMSScanner..."
}
{
  "serverMessage": "Running ServiceAccountKeyScanner..."
}
{
  "serverMessage": "Scan completed!"
```