### PR TITLE
Skip logging error messages for delete pending projects during Inventory creation

### DIFF
--- a/google/cloud/forseti/services/inventory/base/resources.py
+++ b/google/cloud/forseti/services/inventory/base/resources.py
@@ -335,7 +335,7 @@ class Resource(object):
                         res.try_accept(visitor, new_stack)
             except Exception as e:
                 if (isinstance(e, api_errors.ApiExecutionError) and
-                        any(error_str in str(e.http_error) for error_str
+                        any(error_str in str(e) for error_str
                             in skip_errors)):
                     pass
                 else:

--- a/google/cloud/forseti/services/inventory/base/resources.py
+++ b/google/cloud/forseti/services/inventory/base/resources.py
@@ -334,6 +334,8 @@ class Resource(object):
                     else:
                         res.try_accept(visitor, new_stack)
             except Exception as e:
+                # Use string phrases and not error codes since error codes
+                # can mean multiple things.
                 if (isinstance(e, api_errors.ApiExecutionError) and
                         any(error_str in str(e) for error_str
                             in skip_errors)):


### PR DESCRIPTION
References Issue #2731 

Skip logging non-fatal error messages for delete pending projects during Inventory creation in order to declutter logs.

Strings to skip are based on the error outputs seen below:

```<HttpError 403 when requesting https://www.googleapis.com/compute/v1/projects/1069099704666/aggregated/subnetworks?alt=json returned \"Project 1069099704666 has been scheduled for deletion and cannot be used for API calls. Visit https://console.developers.google.com/iam-admin/projects?pendingDeletion=true to undelete the project.\">\n\nGCP API Error: unable to get buckets, project_id = 1051652904419, from GCP:\n<HttpError 400 when requesting https://www.googleapis.com/storage/v1/b?project=1051652904419&alt=json&projection=full returned \"Unknown project id: 1051652904419\">\n{\n \"error\": {\n  \"errors\": [\n   {\n    \"domain\": \"global\",\n    \"reason\": \"invalid\",\n    \"message\": \"Unknown project id: 1051652904419\"\n   }\n  ],\n  \"code\": 400,\n  \"message\": \"Unknown project id: 1051652904419\"\n }\n}\n\n\nGCP API Error: unable to get buckets, project_id = 1069099704666, from GCP:\n<HttpError 400 when requesting https://www.googleapis.com/storage/v1/b?project=1069099704666&alt=json&projection=full returned \"Unknown project id: 1069099704666\">\n{\n \"error\": {\n  \"errors\": [\n   {\n    \"domain\": \"global\",\n    \"reason\": \"invalid\",\n    \"message\": \"Unknown project id: 1069099704666\"\n   }\n  ],\n  \"code\": 400,\n  \"message\": \"Unknown project id: 1069099704666\"\n }\n}\n\n\n"```

```GCP API Error: unable to get hshin-tf-demo;hshin_tf_demo_2 from GCP: <HttpError 404 when requesting https://www.googleapis.com/bigquery/v2/projects/hshin-tf-demo/datasets/hshin_tf_demo_2/tables?alt=json returned "Not found: Project hshin-tf-demo"> {   "error": {     "code": 404,     "message": "Not found: Project hshin-tf-demo",     "errors": [       {         "message": "Not found: Project hshin-tf-demo",         "domain": "global",         "reason": "notFound"       }     ],     "status": "NOT_FOUND"   } } ```