### PR TITLE
[WIP] Customize user-agent header based on configuration

### DIFF
--- a/google/cloud/forseti/common/gcp_api/_base_repository.py
+++ b/google/cloud/forseti/common/gcp_api/_base_repository.py
@@ -276,7 +276,7 @@ class GCPRepository(object):
                  entity_field=None, list_key_field=None, get_key_field=None,
                  max_results_field='maxResults', search_query_field='query',
                  resource_path_template=None, rate_limiter=None,
-                 use_cached_http=True, read_only=False):
+                 use_cached_http=True, read_only=False, inventory_config=None):
         """Constructor.
 
         Args:
@@ -311,6 +311,8 @@ class GCPRepository(object):
                 is used for each request.
             read_only (bool): When set to true, disables any API calls that
                 would modify a resource within the repository.
+            inventory_config(object): Inventory configuration. If present, it
+                is used to customize the user agent field in HTTP headers.
         """
         self.gcp_service = gcp_service
         self.read_only = read_only
@@ -336,6 +338,7 @@ class GCPRepository(object):
         self._search_query_field = search_query_field
         self._resource_path_template = resource_path_template
         self._rate_limiter = rate_limiter
+        self._inventory_config = inventory_config
 
         self._use_cached_http = use_cached_http
         self._local = LOCAL_THREAD

--- a/google/cloud/forseti/common/gcp_api/_base_repository.py
+++ b/google/cloud/forseti/common/gcp_api/_base_repository.py
@@ -153,6 +153,7 @@ class BaseRepositoryClient(object):
                  use_rate_limiter=False,
                  read_only=False,
                  use_versioned_discovery_doc=False,
+                 inventory_config=None,
                  **kwargs):
         """Constructor.
 
@@ -170,6 +171,8 @@ class BaseRepositoryClient(object):
                 would modify a resource within the repository.
             use_versioned_discovery_doc (bool): When set to true, will use the
                 discovery doc with the version suffix in the filename.
+            inventory_config (object): Inventory configuration. If present, it
+                is used to customize the user-agent header.
             **kwargs (dict): Additional args such as version.
         """
         self._use_cached_http = False
@@ -190,8 +193,8 @@ class BaseRepositoryClient(object):
             self._rate_limiter = None
 
         self._read_only = read_only
-
         self.name = api_name
+        self.inventory_config = inventory_config
 
         # Look to see if the API is formally supported in Forseti.
         supported_api = _supported_apis.SUPPORTED_APIS.get(api_name)
@@ -262,7 +265,8 @@ class BaseRepositoryClient(object):
                                     credentials=self._credentials,
                                     rate_limiter=self._rate_limiter,
                                     use_cached_http=self._use_cached_http,
-                                    read_only=self._read_only)
+                                    read_only=self._read_only,
+                                    inventory_config=self.inventory_config)
 
 
 # pylint: enable=too-many-instance-attributes
@@ -312,7 +316,7 @@ class GCPRepository(object):
             read_only (bool): When set to true, disables any API calls that
                 would modify a resource within the repository.
             inventory_config(object): Inventory configuration. If present, it
-                is used to customize the user agent field in HTTP headers.
+                is used to customize the user-agent header.
         """
         self.gcp_service = gcp_service
         self.read_only = read_only

--- a/google/cloud/forseti/common/gcp_api/cloudasset.py
+++ b/google/cloud/forseti/common/gcp_api/cloudasset.py
@@ -35,7 +35,8 @@ class CloudAssetRepositoryClient(_base_repository.BaseRepositoryClient):
     def __init__(self,
                  quota_max_calls=None,
                  quota_period=60.0,
-                 use_rate_limiter=True):
+                 use_rate_limiter=True,
+                 inventory_config=None):
         """Constructor.
 
         Args:
@@ -44,6 +45,7 @@ class CloudAssetRepositoryClient(_base_repository.BaseRepositoryClient):
             quota_period (float): The time period to track requests over.
             use_rate_limiter (bool): Set to false to disable the use of a rate
                 limiter for this service.
+            inventory_config (object): Inventory configuration.
         """
         if not quota_max_calls:
             use_rate_limiter = False
@@ -55,7 +57,8 @@ class CloudAssetRepositoryClient(_base_repository.BaseRepositoryClient):
             API_NAME, versions=['v1'],
             quota_max_calls=quota_max_calls,
             quota_period=quota_period,
-            use_rate_limiter=use_rate_limiter)
+            use_rate_limiter=use_rate_limiter,
+            inventory_config=inventory_config)
 
     # Turn off docstrings for properties.
     # pylint: disable=missing-return-doc, missing-return-type-doc
@@ -115,20 +118,21 @@ class CloudAssetClient(object):
     # Estimation of how long to wait for an async API to complete.
     OPERATION_DELAY_IN_SEC = 5.0
 
-    def __init__(self, global_configs, **kwargs):
+    def __init__(self, inventory_config, **kwargs):
         """Initialize.
 
         Args:
-            global_configs (dict): Global configurations.
+            inventory_config (object): Inventory configuration.
             **kwargs (dict): The kwargs.
         """
         max_calls, quota_period = api_helpers.get_ratelimiter_config(
-            global_configs, API_NAME)
+            inventory_config.get_api_quota_configs(), API_NAME)
 
         self.repository = CloudAssetRepositoryClient(
             quota_max_calls=max_calls,
             quota_period=quota_period,
-            use_rate_limiter=kwargs.get('use_rate_limiter', True))
+            use_rate_limiter=kwargs.get('use_rate_limiter', True),
+            inventory_config=inventory_config)
 
     def export_assets(self, parent, destination_object, content_type=None,
                       asset_types=None, blocking=False, timeout=0):

--- a/google/cloud/forseti/common/util/http_helpers.py
+++ b/google/cloud/forseti/common/util/http_helpers.py
@@ -19,12 +19,14 @@ from google.cloud import forseti as forseti_security
 HTTP_REQUEST_TIMEOUT = 30.0
 
 
-def build_http(http=None):
+def build_http(http=None, inventory_config=None):
     """Set custom Forseti user agent and timeouts on a new http object.
 
     Args:
         http (object): An instance of httplib2.Http, or compatible, used for
             testing.
+        inventory_config (object): Inventory configuration. If present, it
+            is used to customize the user-agent header.
 
     Returns:
         httplib2.Http: An http object with the forseti user agent set.

--- a/google/cloud/forseti/services/inventory/base/cloudasset.py
+++ b/google/cloud/forseti/services/inventory/base/cloudasset.py
@@ -103,8 +103,7 @@ def load_cloudasset_data(session, config):
     # Start by ensuring that there is no existing CAI data in storage.
     _clear_cai_data(session)
 
-    cloudasset_client = cloudasset.CloudAssetClient(
-        config.get_api_quota_configs())
+    cloudasset_client = cloudasset.CloudAssetClient(config)
     imported_assets = 0
 
     root_resources = []


### PR DESCRIPTION
This isn't ready yet, but I'd like to get some early feedback to see if this is on the right track.
So far the plan is to pass InventoryConfig all the way down to build_http() via GCPRepository. Once it's there, we can then customize the user agent header based on the configuration.
2 questions:
* There''s a lot of plumbing involved. Is there a better way of doing this?
* Since the http object lives in the thread local cache, do we need to modify all API clients to make sure that we're initializing it with the configuration?
