### PR TITLE
Add config-validator user agent suffix

### DIFF
--- a/google/cloud/forseti/common/util/http_helpers.py
+++ b/google/cloud/forseti/common/util/http_helpers.py
@@ -18,6 +18,9 @@ from google.cloud import forseti as forseti_security
 # Per request max wait timeout.
 HTTP_REQUEST_TIMEOUT = 30.0
 
+# Custom HTTP user-agent header suffix.
+_USER_AGENT_SUFFIX = ""
+
 
 def build_http(http=None):
     """Set custom Forseti user agent and timeouts on a new http object.
@@ -31,15 +34,27 @@ def build_http(http=None):
     """
     if not http:
         http = httplib2.Http(timeout=HTTP_REQUEST_TIMEOUT)
-    user_agent = 'Python-httplib2/{} (gzip), {}/{}'.format(
+    user_agent = 'Python-httplib2/{} (gzip), {}/{} {}'.format(
         httplib2.__version__,
         forseti_security.__package_name__,
-        forseti_security.__version__)
+        forseti_security.__version__,
+        _USER_AGENT_SUFFIX).strip()
 
-    return set_user_agent(http, user_agent)
+    return _set_user_agent(http, user_agent)
 
 
-def set_user_agent(http, user_agent):
+def set_user_agent_suffix(suffix):
+    """Set custom user agent string suffix. Once set, this suffix will be used
+    in subsequent build_http() invocations.
+
+    Args:
+      suffix(string): Suffix to be appended to the custom user agent header.
+    """
+    global _USER_AGENT_SUFFIX
+    _USER_AGENT_SUFFIX = suffix
+
+
+def _set_user_agent(http, user_agent):
     """Set the user-agent on every request.
 
     Args:

--- a/google/cloud/forseti/common/util/http_helpers.py
+++ b/google/cloud/forseti/common/util/http_helpers.py
@@ -19,7 +19,7 @@ from google.cloud import forseti as forseti_security
 HTTP_REQUEST_TIMEOUT = 30.0
 
 # Custom HTTP user-agent header suffix.
-_USER_AGENT_SUFFIX = ""
+_USER_AGENT_SUFFIX = ''
 
 
 def build_http(http=None):
@@ -50,8 +50,10 @@ def set_user_agent_suffix(suffix):
     Args:
       suffix(string): Suffix to be appended to the custom user agent header.
     """
+    # pylint: disable=global-statement
     global _USER_AGENT_SUFFIX
     _USER_AGENT_SUFFIX = suffix
+    # pylint: enable=global-statement
 
 
 def _set_user_agent(http, user_agent):

--- a/google/cloud/forseti/services/base/config.py
+++ b/google/cloud/forseti/services/base/config.py
@@ -26,6 +26,7 @@ import threading
 
 from future.utils import with_metaclass
 from google.cloud.forseti.common.util import file_loader
+from google.cloud.forseti.common.util import http_helpers
 from google.cloud.forseti.common.util import logger
 from google.cloud.forseti.services import db
 from google.cloud.forseti.services.client import ClientComposition
@@ -397,7 +398,8 @@ class ServiceConfig(AbstractServiceConfig):
                     # Default to disable CloudAsset Inventory if not configured.
                     forseti_inventory_config.get('cai', {'enabled': False}),
                     composite_root_resources=(
-                        forseti_inventory_config.get('composite_root_resources')
+                        forseti_inventory_config.get(
+                            'composite_root_resources')
                     )
                 )
             except ValueError as e:
@@ -405,7 +407,14 @@ class ServiceConfig(AbstractServiceConfig):
 
             # TODO: Create Config classes to store scanner and notifier configs.
             forseti_scanner_config = forseti_config.get('scanner', {})
-
+            # The suffix is used to indicate which major feature is enabled for tracking purposes.
+            # For now only config validator is supported.
+            user_agent_suffix = ''
+            for scanner in forseti_scanner_config.get('scanners', {}):
+                if scanner.get('enabled') and scanner.get('name') == 'config_validator':
+                    user_agent_suffix = 'config-validator'
+                    break
+            http_helpers.set_user_agent_suffix(user_agent_suffix)
             forseti_notifier_config = forseti_config.get('notifier', {})
 
             forseti_global_config = forseti_config.get('global', {})

--- a/google/cloud/forseti/services/base/config.py
+++ b/google/cloud/forseti/services/base/config.py
@@ -407,11 +407,12 @@ class ServiceConfig(AbstractServiceConfig):
 
             # TODO: Create Config classes to store scanner and notifier configs.
             forseti_scanner_config = forseti_config.get('scanner', {})
-            # The suffix is used to indicate which major feature is enabled for tracking purposes.
-            # For now only config validator is supported.
+            # The suffix is used to indicate which major feature is enabled for
+            # tracking purposes. For now only config validator is supported.
             user_agent_suffix = ''
             for scanner in forseti_scanner_config.get('scanners', {}):
-                if scanner.get('enabled') and scanner.get('name') == 'config_validator':
+                if (scanner.get('enabled') and
+                        scanner.get('name') == 'config_validator'):
                     user_agent_suffix = 'config-validator'
                     break
             http_helpers.set_user_agent_suffix(user_agent_suffix)

--- a/tests/common/util/http_helpers_test.py
+++ b/tests/common/util/http_helpers_test.py
@@ -1,0 +1,69 @@
+# Copyright 2019 The Forseti Security Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-1.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test http_helpers utility functions."""
+
+import httplib2
+import unittest.mock as mock
+import unittest
+
+from google.cloud.forseti.common.util import http_helpers
+from tests.unittest_utils import ForsetiTestCase
+
+
+DUMMY_URL = "http://127.0.0.1"
+UA_KEY = "user-agent"
+
+
+class MockResponse(object):
+    def __iter__(self):
+        yield self
+        yield b''
+
+
+class MockHttp(object):
+    def __init__(self):
+        self.headers = {}
+
+    def request(self, uri, method='GET', body=None, headers=None,
+                redirections=httplib2.DEFAULT_MAX_REDIRECTS,
+                connection_type=None):
+        self.headers = headers
+        return MockResponse()
+
+
+class HttpHelpersTest(ForsetiTestCase):
+    """Test http_helpers utility functions."""
+
+    def test_without_suffix(self):
+        http_helpers.set_user_agent_suffix("")
+        mock_http = MockHttp()
+        http = http_helpers.build_http(mock_http)
+        response, content = http.request(DUMMY_URL)
+        self.assertIn(UA_KEY, mock_http.headers)
+        self.assertRegex(
+            mock_http.headers[UA_KEY], r'forseti-security/[0-9.]+$')
+
+    def test_with_suffix(self):
+        http_helpers.set_user_agent_suffix("foobar")
+        mock_http = MockHttp()
+        http = http_helpers.build_http(mock_http)
+        response, content = http.request(DUMMY_URL)
+        self.assertIn(UA_KEY, mock_http.headers)
+        self.assertRegex(
+            mock_http.headers[UA_KEY], r'foobar$')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
When config validator scanner is enabled. This is for tracking the usage of config validator.