### PR TITLE
update violation_data type from config validator scanner from str to dict

### DIFF
--- a/google/cloud/forseti/scanner/scanners/config_validator_scanner.py
+++ b/google/cloud/forseti/scanner/scanners/config_validator_scanner.py
@@ -77,7 +77,7 @@ class ConfigValidatorScanner(base_scanner.BaseScanner):
                 'rule_index': 0,
                 'rule_name': violation.constraint,
                 'violation_type': self.VIOLATION_TYPE,
-                'violation_data': json_format.MessageToJson(
+                'violation_data': json_format.MessageToDict(
                     violation.metadata, including_default_value_fields=True),
                 'resource_data': resource_data,
                 'violation_message': violation.message


### PR DESCRIPTION
- [x] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [x] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [x] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [x] My PR has been functionally tested.
- [x] All of the [tests](https://forsetisecurity.org/docs/latest/develop/dev/testing.html) pass

fixes #2909 

This updates violation_data type from config validator violations from str to dict and makes it consistent with violation_data type of violations from other scanners.
dict type allows keys in violation_data to be sorted and prevents duplicated CSCC findings to be created due to different sequence of keys in violation_data.