### PR TITLE
Normalize network name in FirewallRules when a short network name is supplied

### DIFF
--- a/google/cloud/forseti/enforcer/gce_firewall_enforcer.py
+++ b/google/cloud/forseti/enforcer/gce_firewall_enforcer.py
@@ -321,9 +321,15 @@ class FirewallRules(object):
                     # Don't add the rule if it's network does not match
                     # network_name
                     LOGGER.info('Firewall rule does not apply to network %s, '
-                                'skipping: %s', rule_network,
+                                'skipping: %s', network_name,
                                 json.dumps(new_rule, sort_keys=True))
                     return
+
+                # Normalize network value to full network URL for rules that
+                # already include a network name, so comparison with a rule
+                # from the API will return True
+                new_rule['network'] = build_network_url(self._project,
+                                                        network_name)
             else:
                 new_rule['network'] = build_network_url(self._project,
                                                         network_name)

--- a/tests/enforcer/gce_firewall_enforcer_test.py
+++ b/tests/enforcer/gce_firewall_enforcer_test.py
@@ -202,6 +202,37 @@ class FirewallRulesTest(ForsetiTestCase):
         self.assertSameStructure(constants.EXPECTED_FIREWALL_RULES,
                                  self.firewall_rules.rules)
 
+    def test_add_rules_for_network_short_form(self):
+        """Validate adding rules for network using the short network name.
+
+        Setup:
+          * Create a sample rule with a network short name
+          * Import the rule into a FirewallRules object
+
+        Expected Results:
+          * Imported rules have the correct names and the correct network
+            assigned.
+        """
+        # The rule name should not be changed since the rule includes a
+        # network already.
+        test_rule_name = 'test-rule'
+        test_rule = _GenerateTestRule(test_rule_name)
+
+        # Short network name, value under test
+        test_rule['network'] = 'global/networks/default'
+
+
+        self.firewall_rules.add_rules(
+            [test_rule], network_name='default')
+
+        # Full network name used by API, given project name of test-project
+        expected_network = (
+            'https://www.googleapis.com/compute/v1/projects/test-project/'
+            'global/networks/default')
+
+        self.assertEqual(expected_network,
+                         self.firewall_rules.rules[test_rule_name]['network'])
+
     def test_add_rules_for_network_long_name(self):
         """Validate adding rules for a specific network with a long name.
 
@@ -1473,6 +1504,18 @@ class FirewallRulesAreEqualTest(ForsetiTestCase):
         self.firewall_rules_1.add_rule(self.rule_one)
         self.firewall_rules_2.add_rule(self.rule_two)
         self.assertNotEqual(self.firewall_rules_1, self.firewall_rules_2)
+
+
+def _GenerateTestRule(name):
+    return {
+        'name': name,
+        'network': ('https://www.googleapis.com/compute/beta/projects/'
+                    'test-project/global/networks/fake-network'),
+        'description': 'fake rule description',
+        'direction': 'INGRESS',
+        'allowed': [{'IPProtocol': 'TCP'}],
+        'sourceRanges': ['10.0.0.0/8']
+    }
 
 
 if __name__ == '__main__':

--- a/tests/enforcer/gce_firewall_enforcer_test.py
+++ b/tests/enforcer/gce_firewall_enforcer_test.py
@@ -1509,7 +1509,7 @@ class FirewallRulesAreEqualTest(ForsetiTestCase):
 def _GenerateTestRule(name):
     return {
         'name': name,
-        'network': ('https://www.googleapis.com/compute/beta/projects/'
+        'network': ('https://www.googleapis.com/compute/v1/projects/'
                     'test-project/global/networks/fake-network'),
         'description': 'fake rule description',
         'direction': 'INGRESS',


### PR DESCRIPTION
Thanks for opening a Pull Request!

Here's a handy checklist to ensure your PR goes smoothly.

- [x] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [x] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [x] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [x] My PR has been functionally tested.
- [x] All of the [tests](https://forsetisecurity.org/docs/latest/develop/dev/testing.html) pass
- [x] I have submitted a corresponding PR in the [Forseti Terraform module](https://github.com/forseti-security/terraform-google-forseti) (if applicable).

These guidelines and more can be found in our [contributing guidelines](https://github.com/forseti-security/forseti-security/blob/dev/.github/CONTRIBUTING.md).
