### PR TITLE
Replace mariadb version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN groupadd -g 1000 forseti && \
 
 # Install host dependencies.
 RUN apt-get update  && \
-    apt-get install --no-install-recommends -y libmariadbclient18 && \
+    apt-get install --no-install-recommends -y libmariadb3 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Error from apt:
Package libmariadbclient18 is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  libmariadb3

Thanks for opening a Pull Request!

Here's a handy checklist to ensure your PR goes smoothly.

- [ ] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [ ] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [ ] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [ ] My PR has been functionally tested.
- [ ] All of the [tests](https://forsetisecurity.org/docs/latest/develop/dev/testing.html) pass
- [ ] I have submitted a corresponding PR in the [Forseti Terraform module](https://github.com/forseti-security/terraform-google-forseti) (if applicable).

These guidelines and more can be found in our [contributing guidelines](https://github.com/forseti-security/forseti-security/blob/dev/.github/CONTRIBUTING.md).
