### PR TITLE
Fixing base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ##### BEGIN BASE IMAGE #####
-FROM python:3.6-slim as base
+FROM python:3.6.9-slim-buster as base
 
 ENV HOME=/home/forseti \
     WORK_DIR=/home/forseti/forseti-security \
@@ -26,7 +26,7 @@ RUN groupadd -g 1000 forseti && \
 
 # Install host dependencies.
 RUN apt-get update  && \
-    apt-get install --no-install-recommends -y libmariadbclient18 && \
+    apt-get install --no-install-recommends -y libmariadb3 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The package containing the dependency for the base image changed between stretch and buster.  We will explicitly set it to buster so this won't surprise us in the near term.

Thanks for opening a Pull Request!

Here's a handy checklist to ensure your PR goes smoothly.

- [x] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [x] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [x] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [x] My PR has been functionally tested.
- [x] All of the [tests](https://forsetisecurity.org/docs/latest/develop/dev/testing.html) pass
- [ ] I have submitted a corresponding PR in the [Forseti Terraform module](https://github.com/forseti-security/terraform-google-forseti) (if applicable).

These guidelines and more can be found in our [contributing guidelines](https://github.com/forseti-security/forseti-security/blob/dev/.github/CONTRIBUTING.md).
