### PR TITLE
Updated 'rules_path' to point to GCS

### DIFF
--- a/configs/server/forseti_conf_server.yaml.in
+++ b/configs/server/forseti_conf_server.yaml.in
@@ -211,7 +211,7 @@ scanner:
     # gs://bucket-name/path/for/rules_path
     # if no rules_path is specified, rules are
     # searched in /path/to/forseti_security/rules/
-    rules_path: /home/ubuntu/forseti-security/rules
+    rules_path: gs://{FORSETI_BUCKET}/rules
 
     # Enable the scanners as default to true when integrated for Forseti 2.0.
 


### PR DESCRIPTION
Addresses #2625 .

This would be an added convenince for deploying on GKE.  Since the forseti-server container reads the server config from GCS, and _rules_path_ points to a path on the host, the forseti-server container fails to read any rules, returning no violations.

The workaround is to update the forseti_server_conf.yaml in GCS to point to the rules in GCS.  This PR removes that necessity.