### PR TITLE
use WatchedFileHandler to better handle log rotation of forseti.log

### DIFF
--- a/google/cloud/forseti/common/util/logger.py
+++ b/google/cloud/forseti/common/util/logger.py
@@ -71,7 +71,7 @@ def get_logger(module_name):
 
     if os.path.exists('/var/log/forseti.log'):  # ubuntu on GCE
         try:
-            default_log_handler = logging.FileHandler('/var/log/forseti.log')
+            default_log_handler = logging.handlers.WatchedFileHandler('/var/log/forseti.log')
             default_log_handler.setFormatter(logging.Formatter(FORSETI_LOG_FMT))
         # users of CLI on server vm can not write to /var/log/forseti.log
         except IOError:

--- a/google/cloud/forseti/common/util/logger.py
+++ b/google/cloud/forseti/common/util/logger.py
@@ -71,7 +71,8 @@ def get_logger(module_name):
 
     if os.path.exists('/var/log/forseti.log'):  # ubuntu on GCE
         try:
-            default_log_handler = logging.handlers.WatchedFileHandler('/var/log/forseti.log')
+            default_log_handler = logging.handlers.WatchedFileHandler(
+                '/var/log/forseti.log')
             default_log_handler.setFormatter(logging.Formatter(FORSETI_LOG_FMT))
         # users of CLI on server vm can not write to /var/log/forseti.log
         except IOError:


### PR DESCRIPTION
- [x] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [x] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [x] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [x] My PR has been functionally tested.
- [x] All of the [tests](https://forsetisecurity.org/docs/latest/develop/dev/testing.html) pass
- [ ] I have submitted a corresponding PR in the [Forseti Terraform module](https://github.com/forseti-security/terraform-google-forseti) (if applicable).

[FileHandler](https://docs.python.org/3/library/logging.handlers.html#filehandler) has issue with rotating logs. It sometimes continues to write to the old log file [1] also loses some logs [2].

[WatchedFileHandler](https://docs.python.org/3/library/logging.handlers.html#watchedfilehandler) works better with logrotate, to ensure the application detects changes in log file and continue to write to the new log.

Detailed examples below.

[1] old log file is being written to. There's also data loss in this case because fluentd only sends logs in forseti.log to stackdriver.
```
$ ls -lrt forseti.log*|tail -5
-rw-r----- 1 ubuntu root   28560 Jul 23 06:02 forseti.log.3
-rw-r----- 1 ubuntu root   28560 Jul 24 06:02 forseti.log.2
-rw-r----- 1 ubuntu root   28560 Jul 25 06:02 forseti.log.1
-rw-r----- 1 ubuntu root    2788 Jul 25 08:02 forseti.log
-rw-r--r-- 1 ubuntu root 8396604 Jul 25 08:02 forseti.log.10
```
[2] Updated one of my instances on Jul 22 04:08 am to use WatchedFileHandler without other major changes, subsequent sizes of forseti.log.* increases significantly. 
```
# ls -lrt forseti.log*|tail -10
-rw-r----- 1 ubuntu root  28560 Jul 17 06:01 forseti.log.9
-rw-r----- 1 ubuntu root  28560 Jul 18 06:00 forseti.log.8
-rw-r----- 1 ubuntu root  28560 Jul 19 06:01 forseti.log.7
-rw-r----- 1 ubuntu root  28560 Jul 20 06:01 forseti.log.6
-rw-r----- 1 ubuntu root  28560 Jul 21 06:00 forseti.log.5
-rw-r----- 1 ubuntu root  98628 Jul 22 06:00 forseti.log.4
-rw-r----- 1 ubuntu root 325752 Jul 23 06:00 forseti.log.3
-rw-r----- 1 ubuntu root 388261 Jul 24 06:00 forseti.log.2
-rw-r----- 1 ubuntu root 336708 Jul 25 06:00 forseti.log.1
-rw-r----- 1 ubuntu root  28535 Jul 25 08:03 forseti.log
```
Logs from the cronjob run are sometimes missing from logs. 
Before change:
```
# grep google.cloud.forseti.services.inventory.inventory forseti.log.5
```
After change:
```
# grep google.cloud.forseti.services.inventory.inventory forseti.log.3|wc -l
36
```