### PR TITLE
Fix Missing Group Members in Inventory

### DIFF
--- a/google/cloud/forseti/services/inventory/storage.py
+++ b/google/cloud/forseti/services/inventory/storage.py
@@ -1350,11 +1350,16 @@ class Storage(BaseStorage):
         if self.readonly:
             raise Exception('Opened storage readonly')
 
-        previous_id = self._get_resource_id(resource)
-        if previous_id:
-            resource.set_inventory_key(previous_id)
-            self.update(resource)
-            return
+        resource_data = resource.data()
+        # Group members do not need to be checked if it already exists
+        # in Inventory, as a user can be members in multiple groups.
+        # IOW: group members must always be inserted.
+        if resource_data.get('kind') != 'admin#directory#member':
+            previous_id = self._get_resource_id(resource)
+            if previous_id:
+                resource.set_inventory_key(previous_id)
+                self.update(resource)
+                return
 
         rows = Inventory.from_resource(self.inventory_index, resource)
 

--- a/google/cloud/forseti/services/inventory/storage.py
+++ b/google/cloud/forseti/services/inventory/storage.py
@@ -1353,7 +1353,6 @@ class Storage(BaseStorage):
         resource_data = resource.data()
         # Group members do not need to be checked if it already exists
         # in Inventory, as a user can be members in multiple groups.
-        # IOW: group members must always be inserted.
         if resource_data.get('kind') != 'admin#directory#member':
             previous_id = self._get_resource_id(resource)
             if previous_id:

--- a/tests/services/inventory/storage_test.py
+++ b/tests/services/inventory/storage_test.py
@@ -39,7 +39,7 @@ from google.cloud.forseti.services.inventory.storage import Storage
 
 class ResourceMock(Resource):
 
-    def __init__(self, key, data, res_type, category, parent=None, warning=[], kind=None):
+    def __init__(self, key, data, res_type, category, parent=None, warning=[]):
         self._key = key
         self._data = data
         self._res_type = res_type
@@ -169,9 +169,8 @@ class StorageTest(ForsetiTestCase):
     def test_whether_resource_should_be_inserted_or_updated(self):
         """Whether the resource should be inserted or updated.
 
-        All resources should be checked if they have been previously
-        written.  Except group members, which should not be checked
-        since they can be members of multiple groups.
+        All resources should not be written if they have been previously
+        written. Except group members, where members can be in multiple groups.
         """
 
         engine = create_test_engine()


### PR DESCRIPTION
This fixes the problem where GSuite group membership is not expanded for certain users (issue #2969).  As it turns out, it's because the members who are in multiple groups are not fully inventoried.  Please see if this is a viable solution, before I write the unit test.

![image](https://user-images.githubusercontent.com/6977544/62107957-a74c2a00-b25d-11e9-9c43-a35174c4eacc.png)

Fixes #2969 