### PR TITLE
Update export_assets method to take support different outputs.

### DIFF
--- a/google/cloud/forseti/common/gcp_api/cloudasset.py
+++ b/google/cloud/forseti/common/gcp_api/cloudasset.py
@@ -169,6 +169,9 @@ class CloudAssetClient(object):
                 not exist.
             force (bool): If true, force write rows even on error.
         """
+        # TODO: Uncomment the below code and remove the exception when the
+        # bigquery support is live in the v1 API.
+        #
         # dataset_full_name = 'projects/{}/datasets/{}'.format(project_id,
         #                                                      dataset)
         # return {'bigqueryDestination': {'dataset': dataset_full_name,

--- a/google/cloud/forseti/common/gcp_api/cloudasset.py
+++ b/google/cloud/forseti/common/gcp_api/cloudasset.py
@@ -130,8 +130,57 @@ class CloudAssetClient(object):
             quota_period=quota_period,
             use_rate_limiter=kwargs.get('use_rate_limiter', True))
 
-    def export_assets(self, parent, destination_object, content_type=None,
-                      asset_types=None, blocking=False, timeout=0):
+    @staticmethod
+    def build_gcs_object_output(destination_object):
+        """Creates an OutputConfig message for output to GCS object.
+
+        Args:
+            destination_object (str): The GCS path and file name to store the
+                results in. The bucket must be in the same project that has the
+                Cloud Asset API enabled and the object must not exist.
+
+        Returns:
+            dict: an OutputConfig message.
+        """
+        return {'gcsDestination': {'uri': destination_object}}
+
+    @staticmethod
+    def build_gcs_prefix_output(destination_prefix):
+        """Creates an OutputConfig message for sharding output to a GCS prefix.
+
+        Args:
+            destination_prefix (str): The GCS bucket and folder path to store
+                the results in. The bucket must be in the same project that has
+                the Cloud Asset API enabled and the folder must not exist.
+
+        Returns:
+            dict: an OutputConfig message.
+        """
+        return {'gcsDestination': {'uriPrefix': destination_prefix}}
+
+    @staticmethod
+    def build_bigquery_table_output(project_id, dataset, table, force=True):
+        """Creates an OutputConfig message for output to a BigQuery table.
+
+        Args:
+            project_id (str): The project that hosts the dataset.
+            dataset (str): The dataset name to output into.
+            table (str): The table name to create for the export, the table must
+                not exist.
+            force (bool): If true, force write rows even on error.
+        """
+        # dataset_full_name = 'projects/{}/datasets/{}'.format(project_id,
+        #                                                      dataset)
+        # return {'bigqueryDestination': {'dataset': dataset_full_name,
+        #                                 'table': table,
+        #                                 "force": force}}
+        raise NotImplementedError('The v1 API does not support this '
+                                  'destination, it will be enabled in a future '
+                                  'release.')
+
+    def export_assets(self, parent, destination_object=None, output_config=None,
+                      content_type=None, asset_types=None, blocking=False,
+                      timeout=0):
         """Export assets under a parent resource to the destination GCS object.
 
         Args:
@@ -140,6 +189,9 @@ class CloudAssetClient(object):
             destination_object (str): The GCS path and file name to store the
                 results in. The bucket must be in the same project that has the
                 Cloud Asset API enabled.
+            output_config (dict): The full outputConfig message to pass to the
+                export assets API. Should be built using one of the
+                build_*_output_config methods.
             content_type (str): The specific content type to export, currently
                 supports "RESOURCE" and "IAM_POLICY". If not specified only the
                 CAI metadata for assets are included.
@@ -165,10 +217,25 @@ class CloudAssetClient(object):
             raise ValueError('parent must start with folders/, projects/, or '
                              'organizations/')
 
+        if not destination_object and not output_config:
+            raise ValueError('Either destination_object or output_config must '
+                             'be set.')
+
+        if destination_object and output_config:
+            raise ValueError('destination_object and output_config must be not '
+                             'both be specified.')
+
+        if destination_object:
+            # Explicitly continue to support the original use of this method,
+            # which was output to a specific GCS object. There may be usage of
+            # this method from outside of Forseti, and thus backwards
+            # compatibility is required.
+            output_config = self.build_gcs_object_output(destination_object)
+
         repository = self.repository.top_level
         try:
             results = repository.export_assets(
-                parent, destination_object, content_type=content_type,
+                parent, output_config, content_type=content_type,
                 asset_types=asset_types)
             if blocking:
                 results = self.wait_for_completion(parent, results,

--- a/google/cloud/forseti/common/gcp_api/repository_mixins.py
+++ b/google/cloud/forseti/common/gcp_api/repository_mixins.py
@@ -262,17 +262,17 @@ class OrgPolicyQueryMixin(object):
 class ExportAssetsQueryMixin(object):
     """Mixin that implements the exportAssets query."""
 
-    def export_assets(self, parent, destination_object,
-                      content_type=None, asset_types=None,
-                      fields=None, verb='exportAssets', **kwargs):
+    def export_assets(self, parent, output_config, content_type=None,
+                      asset_types=None, fields=None, verb='exportAssets',
+                      **kwargs):
         """Export assets under a parent resource to a file on GCS.
 
         Args:
             parent (str): The name of the parent resource to export assests
                 under.
-            destination_object (str): The GCS path and file name to store the
-                results in. The bucket must be in the same project that has the
-                Cloud Asset API enabled.
+            output_config (dict): The full outputConfig message to pass to the
+                export assets API.
+                https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/reference/rest/v1/TopLevel/exportAssets#OutputConfig
             content_type (str): The specific content type to export, currently
                 supports "RESOURCE" and "IAM_POLICY". If not specified only the
                 CAI metadata for assets are included.
@@ -286,8 +286,9 @@ class ExportAssetsQueryMixin(object):
             dict: The response from the API.
         """
         body = {
-            'outputConfig': {'gcsDestination': {'uri': destination_object}}
+            'outputConfig': output_config
         }
+
         if content_type:
             body['contentType'] = content_type
 

--- a/tests/common/gcp_api/cloudasset_test.py
+++ b/tests/common/gcp_api/cloudasset_test.py
@@ -239,7 +239,7 @@ class CloudAssetTest(unittest_utils.ForsetiTestCase):
 
     def test_export_assets_valueerror_bad_parent(self):
         """Test export_assets for an invalid parent."""
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, 'parent must start'):
             self.asset_api_client.export_assets(
                 'serviceaccounts/123454321',
                 output_config=self.default_output_config,
@@ -247,16 +247,18 @@ class CloudAssetTest(unittest_utils.ForsetiTestCase):
 
     def test_export_assets_valueerror_no_output(self):
         """Test export_assets for an missing output config."""
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError,
+                                    'destination_object or output_config'):
             self.asset_api_client.export_assets(
-                'serviceaccounts/123454321',
+                fake_cloudasset.PROJECT,
                 content_type='RESOURCE')
 
     def test_export_assets_valueerror_destination_and_output(self):
         """Test export_assets for both destination object and output config."""
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError,
+                                    'destination_object and output_config'):
             self.asset_api_client.export_assets(
-                'serviceaccounts/123454321',
+                fake_cloudasset.PROJECT,
                 fake_cloudasset.DESTINATION,
                 output_config=self.default_output_config,
                 content_type='RESOURCE')


### PR DESCRIPTION
* Create helper functions to build correct Output Config message for each supported destination.
* Update mixin to expect an OutputConfig dict instead of a destination object.
* Add stub for bigquery destination pending support in v1 API.

Thanks for opening a Pull Request!

Here's a handy checklist to ensure your PR goes smoothly.

- [x] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [x] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [x] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [x] My PR has been functionally tested.
- [x] All of the [tests](https://forsetisecurity.org/docs/latest/develop/dev/testing.html) pass
- [x] I have submitted a corresponding PR in the [Forseti Terraform module](https://github.com/forseti-security/terraform-google-forseti) (if applicable).

These guidelines and more can be found in our [contributing guidelines](https://github.com/forseti-security/forseti-security/blob/dev/.github/CONTRIBUTING.md).
