### PR TITLE
Speed up import of cloudasset data into temporary sql table.

### DIFF
--- a/google/cloud/forseti/services/inventory/crawler.py
+++ b/google/cloud/forseti/services/inventory/crawler.py
@@ -305,20 +305,19 @@ def _api_client_factory(storage, config, parallel):
     client_config = config.get_api_quota_configs()
     client_config['domain_super_admin_email'] = config.get_gsuite_admin_email()
     client_config['excluded_resources'] = config.get_excluded_resources()
-    asset_count = 0
     if config.get_cai_enabled():
         # TODO: When CAI supports resource exclusion, update the following
         #       method to handle resource exclusion during export time.
-        asset_count = cloudasset.load_cloudasset_data(storage.session, config)
+        engine = config.get_service_config().get_engine()
+        asset_count = cloudasset.load_cloudasset_data(engine, config)
         LOGGER.info('%s total assets loaded from Cloud Asset data.',
                     asset_count)
 
-    if asset_count:
-        engine = config.get_service_config().get_engine()
-        return cai_gcp_client.CaiApiClientImpl(client_config,
-                                               engine,
-                                               parallel,
-                                               storage.session)
+        if asset_count:
+            return cai_gcp_client.CaiApiClientImpl(client_config,
+                                                   engine,
+                                                   parallel,
+                                                   storage.session)
 
     # Default to the non-CAI implementation
     return gcp.ApiClientImpl(client_config)

--- a/tests/services/inventory/crawling_test.py
+++ b/tests/services/inventory/crawling_test.py
@@ -725,13 +725,13 @@ class CloudAssetCrawlerTest(CrawlerBase):
                         # Validate export_assets called with asset_types
                         expected_calls = [
                             mock.call(gcp_api_mocks.ORGANIZATION_ID,
-                                      mock.ANY,
+                                      output_config=mock.ANY,
                                       content_type='RESOURCE',
                                       asset_types=asset_types,
                                       blocking=mock.ANY,
                                       timeout=mock.ANY),
                             mock.call(gcp_api_mocks.ORGANIZATION_ID,
-                                      mock.ANY,
+                                      output_config=mock.ANY,
                                       content_type='IAM_POLICY',
                                       asset_types=asset_types,
                                       blocking=mock.ANY,

--- a/tests/services/inventory/storage_test.py
+++ b/tests/services/inventory/storage_test.py
@@ -335,14 +335,14 @@ class CaiTemporaryStoreTest(ForsetiTestCase):
     def _add_resources(self):
         """Add CAI resources to temporary table."""
         resource_data = StringIO(CAI_RESOURCE_DATA)
-        rows = CaiDataAccess.populate_cai_data(resource_data, self.session)
+        rows = CaiDataAccess.populate_cai_data(resource_data, self.engine)
         expected_rows = len(CAI_RESOURCE_DATA.split('\n'))
         self.assertEqual(expected_rows, rows)
 
     def _add_iam_policies(self):
         """Add CAI IAM Policies to temporary table."""
         iam_policy_data = StringIO(CAI_IAM_POLICY_DATA)
-        rows = CaiDataAccess.populate_cai_data(iam_policy_data, self.session)
+        rows = CaiDataAccess.populate_cai_data(iam_policy_data, self.engine)
         expected_rows = len(CAI_IAM_POLICY_DATA.split('\n'))
         self.assertEqual(expected_rows, rows)
 
@@ -355,7 +355,7 @@ class CaiTemporaryStoreTest(ForsetiTestCase):
         """Validate CAI data delete."""
         self._add_resources()
 
-        rows = CaiDataAccess.clear_cai_data(self.session)
+        rows = CaiDataAccess.clear_cai_data(self.engine)
         expected_rows = len(CAI_RESOURCE_DATA.split('\n'))
         self.assertEqual(expected_rows, rows)
 


### PR DESCRIPTION
* Strip unused data before writing to the database
* Switch from SQLAlchemy ORM to Core style bulk CAI inserts
* Ensure the maximum number of rows are written on each bulk insert

This is one of a series of changes to reduce the time to complete
a forseti inventory snapshot for large organizations.

This change reduces the time to import data into a cloudsql database
from a test system by about 50%, from about 312 seconds to about 144
seconds for around 350 megabytes of raw data.

Thanks for opening a Pull Request!

Here's a handy checklist to ensure your PR goes smoothly.

- [x] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [x] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [x] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [x] My PR has been functionally tested.
- [x] All of the [tests](https://forsetisecurity.org/docs/latest/develop/dev/testing.html) pass
- [x] I have submitted a corresponding PR in the [Forseti Terraform module](https://github.com/forseti-security/terraform-google-forseti) (if applicable).

These guidelines and more can be found in our [contributing guidelines](https://github.com/forseti-security/forseti-security/blob/dev/.github/CONTRIBUTING.md).
