### PR TITLE
Stream CloudAsset data straight to sqlite database.

### DIFF
--- a/google/cloud/forseti/services/inventory/base/cloudasset.py
+++ b/google/cloud/forseti/services/inventory/base/cloudasset.py
@@ -97,6 +97,7 @@ DEFAULT_ASSET_TYPES = [
     'storage.googleapis.com/Bucket',
 ]
 
+
 class StreamError(Exception):
     """Raised for errors streaming results from GCS to local DB."""
 
@@ -162,6 +163,7 @@ def _stream_cloudasset_worker(cai_data, engine, output_queue):
         output_queue (collections.deque): A queue storing the results of this
             thread.
     """
+    # Codecs transforms the raw byte stream into an iterable of lines.
     cai_iter = codecs.getreader('utf-8')(cai_data)
     rows = cai_temporary_storage.CaiDataAccess.populate_cai_data(
         cai_iter, engine)

--- a/google/cloud/forseti/services/inventory/base/cloudasset.py
+++ b/google/cloud/forseti/services/inventory/base/cloudasset.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 """Forseti Inventory Cloud Asset API integration."""
-
+import codecs
+from collections import deque
 import os
+import threading
 import time
 
 import concurrent.futures
@@ -22,10 +24,9 @@ from googleapiclient import errors
 
 from google.cloud.forseti.common.gcp_api import cloudasset
 from google.cloud.forseti.common.gcp_api import errors as api_errors
-from google.cloud.forseti.common.util import file_loader
+from google.cloud.forseti.common.gcp_api import storage
 from google.cloud.forseti.common.util import logger
-from google.cloud.forseti.services.inventory.cai_temporary_storage import (
-    CaiDataAccess)
+from google.cloud.forseti.services.inventory import cai_temporary_storage
 
 LOGGER = logger.get_logger(__name__)
 CONTENT_TYPES = ['RESOURCE', 'IAM_POLICY']
@@ -96,6 +97,9 @@ DEFAULT_ASSET_TYPES = [
     'storage.googleapis.com/Bucket',
 ]
 
+class StreamError(Exception):
+    """Raised for errors streaming results from GCS to local DB."""
+
 
 def load_cloudasset_data(engine, config):
     """Export asset data from Cloud Asset API and load into storage.
@@ -108,12 +112,9 @@ def load_cloudasset_data(engine, config):
         int: The count of assets imported into the database, or None if there
             is an error.
     """
-    # Start by ensuring that there is no existing CAI data in storage.
-    _clear_cai_data(engine)
-
     cloudasset_client = cloudasset.CloudAssetClient(
         config.get_api_quota_configs())
-    imported_assets = 0
+    storage_client = storage.StorageClient()
 
     root_resources = []
     if config.use_composite_root():
@@ -121,6 +122,7 @@ def load_cloudasset_data(engine, config):
     else:
         root_resources.append(config.get_root_resource_id())
 
+    imported_assets = 0
     with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
         futures = []
         for root_id in root_resources:
@@ -132,23 +134,100 @@ def load_cloudasset_data(engine, config):
                                                content_type))
 
         for future in concurrent.futures.as_completed(futures):
-            temporary_file = ''
+            gcs_object = future.result()
             try:
-                temporary_file = future.result()
-                if not temporary_file:
-                    return _clear_cai_data(engine)
+                assets = _stream_gcs_to_database(gcs_object,
+                                                 engine,
+                                                 storage_client)
+                imported_assets += assets
+            except StreamError as e:
+                LOGGER.error('Error streaming data from GCS to Database: %s', e)
+                return _clear_cai_data(engine)
 
-                LOGGER.debug('Importing Cloud Asset data from %s to database.',
-                             temporary_file)
-                with open(temporary_file, 'r') as cai_data:
-                    rows = CaiDataAccess.populate_cai_data(cai_data, engine)
-                    imported_assets += rows
-                    LOGGER.info('%s assets imported to database.', rows)
-            finally:
-                if temporary_file:
-                    os.unlink(temporary_file)
+    # Each worker's imported asset count is appended to the deque, sum them all
+    # to get total imported assets.
+    LOGGER.info('%i assets imported to database.', imported_assets)
 
+    # Optimize the new database before returning
+    engine.execute('pragma optimize;')
     return imported_assets
+
+
+def _stream_cloudasset_worker(cai_data, engine, output_queue):
+    """Worker to stream data from GCS into sqlite temporary table.
+
+    Args:
+        cai_data (file): An open file like pipe.
+        engine (sqlalchemy.engine.Engine): Database engine to write data to.
+        output_queue (collections.deque): A queue storing the results of this
+            thread.
+    """
+    cai_iter = codecs.getreader('utf-8')(cai_data)
+    rows = cai_temporary_storage.CaiDataAccess.populate_cai_data(
+        cai_iter, engine)
+    LOGGER.info('%s assets imported to database.', rows)
+    output_queue.append(rows)
+
+
+def _stream_gcs_to_database(gcs_object, engine, storage_client):
+    """Stream data from GCS into a local database using pipes.
+
+    Args:
+        gcs_object (str): The full path to the GCS object to read.
+        engine (sqlalchemy.engine.Engine): The db engine to store the data in.
+        storage_client (storage.StorageClient): The storage client to use to
+            download data from GCS.
+
+    Returns:
+        int: The number of rows stored in the database.
+
+    Raises:
+        StreamError: Raised on any errors streaming data from GCS.
+    """
+    if not gcs_object:
+        raise StreamError('GCS Object name not defined.')
+
+    LOGGER.info('Importing Cloud Asset data from %s to database.',
+                gcs_object)
+
+    # Use a deque to store the output of the worker threads as appends are
+    # atomic and thread safe.
+    imported_rows = deque()
+
+    # Create a pair of connected pipe objects to stream the data from
+    # GCS into the sqlite database without having to download the data
+    # to the local system first.
+    read_pipe, write_pipe = os.pipe()
+    # Create file like objects for each pipe
+    read_file = os.fdopen(read_pipe, mode='rb')
+    write_file = os.fdopen(write_pipe, mode='wb')
+    # Create a separate thread for writing the data to sqlite, reading
+    # from the input side of the pipe.
+    worker = threading.Thread(target=_stream_cloudasset_worker,
+                              args=(read_file, engine, imported_rows))
+    worker.start()
+
+    try:
+        # Stream data from GCS into the output side of the pip
+        storage_client.download(full_bucket_path=gcs_object,
+                                output_file=write_file)
+    except errors.HttpError as e:
+        LOGGER.error('Could not download %s from GCS: %s',
+                     gcs_object, e)
+        raise StreamError('Could not download %s from GCS : %s' %
+                          (gcs_object, e))
+    finally:
+        # Close the write side of the pipe so the read side will know
+        # when it reaches EOF and the tread will return.
+        write_file.close()
+
+        # Wait for thread to complete before continuing
+        worker.join()
+
+        # Don't leak resources, ensure both sides of pipe are closed.
+        read_file.close()
+
+    return imported_rows.popleft()
 
 
 def _export_assets(cloudasset_client, config, root_id, content_type):
@@ -161,8 +240,7 @@ def _export_assets(cloudasset_client, config, root_id, content_type):
         content_type (ContentTypes): The content type to export.
 
     Returns:
-        str: The path to the temporary file downloaded from GCS or None on
-            error.
+        str: The path to the GCS object created by the CloudAsset API.
 
     Raises:
         ValueError: Raised if the server configuration for CAI export is
@@ -212,12 +290,7 @@ def _export_assets(cloudasset_client, config, root_id, content_type):
                      '%s', results)
         return None
 
-    try:
-        LOGGER.debug('Downloading Cloud Asset data from GCS to disk.')
-        return file_loader.copy_file_from_gcs(export_path)
-    except errors.HttpError as e:
-        LOGGER.warning('Download of CAI dump from GCS failed: %s', e)
-        return None
+    return export_path
 
 
 def _clear_cai_data(engine):
@@ -227,7 +300,7 @@ def _clear_cai_data(engine):
         engine (object): Database engine.
     """
     LOGGER.debug('Deleting Cloud Asset data from database.')
-    count = CaiDataAccess.clear_cai_data(engine)
+    count = cai_temporary_storage.CaiDataAccess.clear_cai_data(engine)
     LOGGER.debug('%s assets deleted from database.', count)
     return None
 

--- a/tests/services/inventory/crawling_test.py
+++ b/tests/services/inventory/crawling_test.py
@@ -17,14 +17,15 @@ import copy
 import os
 import unittest
 import unittest.mock as mock
-from sqlalchemy.orm import sessionmaker
 from tests.services.inventory import gcp_api_mocks
-from tests.services.util.db import create_test_engine_with_file
 from tests.services.util.mock import MockServerConfig
 from tests import unittest_utils
-from google.cloud.forseti.common.util import file_loader
+import google.auth
+from google.oauth2 import credentials
+from google.cloud.forseti.common.gcp_api import storage
 from google.cloud.forseti.common.util import logger
 from google.cloud.forseti.services.base.config import InventoryConfig
+from google.cloud.forseti.services.inventory import cai_temporary_storage
 from google.cloud.forseti.services.inventory.storage import initialize
 from google.cloud.forseti.services.inventory.base.progress import Progresser
 from google.cloud.forseti.services.inventory.base.storage import Memory as MemoryStorage
@@ -153,20 +154,19 @@ class CrawlerBase(unittest_utils.ForsetiTestCase):
 
         return result_counts
 
-    def _run_crawler(self, config, has_org_access=True, session=None):
+    def _run_crawler(self, config, has_org_access=True):
         """Runs the crawler with a specific InventoryConfig.
 
         Args:
             config (InventoryConfig): The configuration to test.
             has_org_access (bool): True if crawler has access to the org
                 resource.
-            session (object): An existing sql session, required for testing
-                Cloud Asset API integration.
+            client (object): An API Client implementation, used for CAI testing.
 
         Returns:
             dict: the resource counts returned by the crawler.
         """
-        with MemoryStorage(session=session) as storage:
+        with MemoryStorage() as storage:
             progresser = NullProgresser()
             with gcp_api_mocks.mock_gcp(has_org_access=has_org_access):
                 run_crawler(storage,
@@ -490,10 +490,6 @@ class CloudAssetCrawlerTest(CrawlerBase):
     def setUp(self):
         """Setup method."""
         CrawlerBase.setUp(self)
-        self.engine, self.dbfile = create_test_engine_with_file()
-        session_maker = sessionmaker()
-        self.session = session_maker(bind=self.engine)
-        initialize(self.engine)
         self.inventory_config = InventoryConfig(gcp_api_mocks.ORGANIZATION_ID,
                                                 '',
                                                 {},
@@ -501,42 +497,54 @@ class CloudAssetCrawlerTest(CrawlerBase):
                                                 {'enabled': True,
                                                  'gcs_path': 'gs://test-bucket'}
                                                )
-        self.inventory_config.set_service_config(FakeServerConfig(self.engine))
+        self.inventory_config.set_service_config(
+            FakeServerConfig('mock_engine'))
 
-        # Ensure test data doesn't get deleted
-        self.mock_unlink = mock.patch.object(
-            os, 'unlink', autospec=True).start()
-        self.mock_copy_file_from_gcs = mock.patch.object(
-            file_loader,
-            'copy_file_from_gcs',
-            autospec=True).start()
         self.maxDiff = None
 
-        # Mock copy_file_from_gcs to return correct test data file
-        def _copy_file_from_gcs(file_path, *args, **kwargs):
-            """Fake copy_file_from_gcs."""
-            del args, kwargs
-            if 'resource' in file_path:
-                return os.path.join(TEST_RESOURCE_DIR_PATH,
-                                    'mock_cai_resources.dump')
-            elif 'iam_policy' in file_path:
-                return os.path.join(TEST_RESOURCE_DIR_PATH,
-                                    'mock_cai_iam_policies.dump')
+    def _run_crawler(self, config):
+        """Runs the crawler with a specific InventoryConfig.
 
-        self.mock_copy_file_from_gcs.side_effect = _copy_file_from_gcs
+        Args:
+            config (InventoryConfig): The configuration to test.
+
+        Returns:
+            dict: the resource counts returned by the crawler.
+        """
+        # Mock download to return correct test data file
+        def _fake_download(full_bucket_path, output_file):
+            if 'resource' in full_bucket_path:
+                fake_file = os.path.join(TEST_RESOURCE_DIR_PATH,
+                                         'mock_cai_resources.dump')
+            elif 'iam_policy' in full_bucket_path:
+                fake_file = os.path.join(TEST_RESOURCE_DIR_PATH,
+                                         'mock_cai_iam_policies.dump')
+            with open(fake_file, 'rb') as f:
+                output_file.write(f.read())
+
+        with MemoryStorage() as storage:
+            progresser = NullProgresser()
+            with gcp_api_mocks.mock_gcp() as gcp_mocks:
+                gcp_mocks.mock_storage.download.side_effect = _fake_download
+                run_crawler(storage,
+                            progresser,
+                            config,
+                            parallel=True)
+
+            self.assertEqual(0,
+                             progresser.errors,
+                             'No errors should have occurred')
+
+            return self._get_resource_counts_from_storage(storage)
 
     def tearDown(self):
         """tearDown."""
         CrawlerBase.tearDown(self)
         mock.patch.stopall()
 
-        # Stop mocks before unlinking the database file.
-        os.unlink(self.dbfile)
-
     def test_cai_crawl_to_memory(self):
         """Crawl mock environment, test that there are items in storage."""
-        result_counts = self._run_crawler(self.inventory_config,
-                                          session=self.session)
+        result_counts = self._run_crawler(self.inventory_config)
 
         expected_counts = copy.deepcopy(GCP_API_RESOURCES)
         expected_counts.update({
@@ -600,8 +608,7 @@ class CloudAssetCrawlerTest(CrawlerBase):
             'sqladmin': {'disable_polling': True},
             'storage': {'disable_polling': True},
         }
-        result_counts = self._run_crawler(self.inventory_config,
-                                          session=self.session)
+        result_counts = self._run_crawler(self.inventory_config)
         # Any resource not included in Cloud Asset export will not be in the
         # inventory.
         expected_counts = {
@@ -681,7 +688,7 @@ class CloudAssetCrawlerTest(CrawlerBase):
                                             'gcs_path': 'gs://test-bucket',
                                             'asset_types': asset_types}
                                           )
-        inventory_config.set_service_config(FakeServerConfig(self.engine))
+        inventory_config.set_service_config(FakeServerConfig('fake_engine'))
 
         # Create subsets of the mock resource dumps that only contain the
         # filtered asset types
@@ -707,17 +714,20 @@ class CloudAssetCrawlerTest(CrawlerBase):
 
         with unittest_utils.create_temp_file(filtered_assets) as resources:
             with unittest_utils.create_temp_file(filtered_iam) as iam_policies:
-                def _copy_file_from_gcs(file_path, *args, **kwargs):
-                    """Fake copy_file_from_gcs."""
-                    del args, kwargs
-                    if 'resource' in file_path:
-                        return resources
-                    elif 'iam_policy' in file_path:
-                        return iam_policies
-                self.mock_copy_file_from_gcs.side_effect = _copy_file_from_gcs
-                with MemoryStorage(session=self.session) as storage:
+                # Mock download to return correct test data file
+                def _fake_download(full_bucket_path, output_file):
+                    if 'resource' in full_bucket_path:
+                        fake_file = resources
+                    elif 'iam_policy' in full_bucket_path:
+                        fake_file = iam_policies
+                    with open(fake_file, 'rb') as f:
+                        output_file.write(f.read())
+
+                with MemoryStorage() as storage:
                     progresser = NullProgresser()
                     with gcp_api_mocks.mock_gcp() as gcp_mocks:
+                        gcp_mocks.mock_storage.download.side_effect = (
+                            _fake_download)
                         run_crawler(storage,
                                     progresser,
                                     inventory_config)

--- a/tests/services/inventory/crawling_test.py
+++ b/tests/services/inventory/crawling_test.py
@@ -20,9 +20,6 @@ import unittest.mock as mock
 from tests.services.inventory import gcp_api_mocks
 from tests.services.util.mock import MockServerConfig
 from tests import unittest_utils
-import google.auth
-from google.oauth2 import credentials
-from google.cloud.forseti.common.gcp_api import storage
 from google.cloud.forseti.common.util import logger
 from google.cloud.forseti.services.base.config import InventoryConfig
 from google.cloud.forseti.services.inventory import cai_temporary_storage


### PR DESCRIPTION
* Change cloudasset implementation to stream data from GCS to the local
sqlite database using OS pipes instead of downloading the full file to a
temporary location and then reading it from there.

This change reduces storage requirements on Forseti Server and allows
data to be processed only once instead of writing and rereading each row
of data from the CloudAsset export.

Thanks for opening a Pull Request!

Here's a handy checklist to ensure your PR goes smoothly.

- [ ] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [ ] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [ ] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [ ] My PR has been functionally tested.
- [ ] All of the [tests](https://forsetisecurity.org/docs/latest/develop/dev/testing.html) pass
- [ ] I have submitted a corresponding PR in the [Forseti Terraform module](https://github.com/forseti-security/terraform-google-forseti) (if applicable).

These guidelines and more can be found in our [contributing guidelines](https://github.com/forseti-security/forseti-security/blob/dev/.github/CONTRIBUTING.md).
