### PR TITLE
Add try except block for CAI export

### DIFF
--- a/google/cloud/forseti/common/gcp_api/appengine.py
+++ b/google/cloud/forseti/common/gcp_api/appengine.py
@@ -430,7 +430,7 @@ class AppEngineClient(object):
                          project_id, service_id, version_id, flattened_results)
             return flattened_results
         except (errors.HttpError, HttpLib2Error) as e:
-            if e.resp.status == 501:  # pylint: disable=no-member
+            if e.resp.status == 501:
                 LOGGER.debug(e)
                 return []
             if _is_status_not_found(e):

--- a/google/cloud/forseti/services/inventory/base/cloudasset.py
+++ b/google/cloud/forseti/services/inventory/base/cloudasset.py
@@ -180,13 +180,30 @@ def _export_assets(cloudasset_client, config, root_id, content_type):
         if asset_types:
             LOGGER.info('Limiting export to the following asset types: %s',
                         asset_types)
+        try:
+            results = cloudasset_client.export_assets(root_id,
+                                                      export_path,
+                                                      content_type=content_type,
+                                                      asset_types=asset_types,
+                                                      blocking=True,
+                                                      timeout=timeout)
+        except api_errors.ApiExecutionError as e:
+            if e.http_error.resp.status == 400:
+                LOGGER.warning('Bad request with unsupported resource types '
+                               'sent to CAI for %s under %s. Exporting all '
+                               'resources for Cloud Asset export.',
+                               content_type, root_id)
+                results = cloudasset_client.export_assets(
+                    root_id,
+                    export_path,
+                    content_type=content_type,
+                    asset_types=[],
+                    blocking=True,
+                    timeout=timeout)
+            else:
+                LOGGER.warning('API Error getting cloud asset data: %s', e)
+                return None
 
-        results = cloudasset_client.export_assets(root_id,
-                                                  export_path,
-                                                  content_type=content_type,
-                                                  asset_types=asset_types,
-                                                  blocking=True,
-                                                  timeout=timeout)
         LOGGER.debug('Cloud Asset export for %s under %s to GCS '
                      'object %s completed, result: %s.',
                      content_type, root_id, export_path, results)

--- a/pylintrc
+++ b/pylintrc
@@ -269,7 +269,7 @@ ignored-argument-names=_.*
 max-locals=16
 
 # Maximum number of return / yield for function / method body
-max-returns=6
+max-returns=7
 
 # Maximum number of branch for function / method body
 max-branches=12


### PR DESCRIPTION
Cloud Asset Inventory is temporarily disabling support for the following data:

- k8s.io/Node
- k8s.io/Pod
- k8s.io/Namespace

Add try-except block for CAI export to handle disablement of resources.