### PR TITLE
Fix auth in the jekyll website build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -46,7 +46,7 @@ markdown: kramdown
 destination: _www/www/
 
 # Needed for local builds and using {{ site.github }}.
-repository: GoogleCloudPlatform/forseti-security
+repository: forseti-security/forseti-security
 title: "Forseti Security"
 
 # Jekyll related directives.


### PR DESCRIPTION
By specifying the correct organization when the forseti-security-travis-bot credentials are used.