### PR TITLE
Add Spans for CAI and API Operations

### DIFF
--- a/google/cloud/forseti/common/gcp_api/bigquery.py
+++ b/google/cloud/forseti/common/gcp_api/bigquery.py
@@ -238,7 +238,7 @@ class BigQueryClient(object):
         except (errors.HttpError, HttpLib2Error) as e:
             raise api_errors.ApiExecutionError(project_id, e)
 
-    @tracing.traced()
+    @tracing.trace()
     def get_tables(self, project_id, dataset_id):
         """Return BigQuery tables stored in the requested project_id.
 

--- a/google/cloud/forseti/common/gcp_api/bigquery.py
+++ b/google/cloud/forseti/common/gcp_api/bigquery.py
@@ -21,6 +21,7 @@ from google.cloud.forseti.common.gcp_api import _base_repository
 from google.cloud.forseti.common.gcp_api import api_helpers
 from google.cloud.forseti.common.gcp_api import errors as api_errors
 from google.cloud.forseti.common.gcp_api import repository_mixins
+from google.cloud.forseti.common.opencensus import tracing
 from google.cloud.forseti.common.util import logger
 
 LOGGER = logger.get_logger(__name__)
@@ -237,6 +238,7 @@ class BigQueryClient(object):
         except (errors.HttpError, HttpLib2Error) as e:
             raise api_errors.ApiExecutionError(project_id, e)
 
+    @tracing.traced()
     def get_tables(self, project_id, dataset_id):
         """Return BigQuery tables stored in the requested project_id.
 

--- a/google/cloud/forseti/common/gcp_api/servicemanagement.py
+++ b/google/cloud/forseti/common/gcp_api/servicemanagement.py
@@ -21,6 +21,7 @@ from google.cloud.forseti.common.gcp_api import _base_repository
 from google.cloud.forseti.common.gcp_api import api_helpers
 from google.cloud.forseti.common.gcp_api import errors as api_errors
 from google.cloud.forseti.common.gcp_api import repository_mixins
+from google.cloud.forseti.common.opencensus import tracing
 from google.cloud.forseti.common.util import logger
 
 LOGGER = logger.get_logger(__name__)
@@ -121,6 +122,7 @@ class _ServiceManagementServicesRepository(
         return service_name
 
 
+@tracing.traced()
 class ServiceManagementClient(object):
     """Service Management Client."""
 

--- a/google/cloud/forseti/common/gcp_api/servicemanagement.py
+++ b/google/cloud/forseti/common/gcp_api/servicemanagement.py
@@ -122,7 +122,6 @@ class _ServiceManagementServicesRepository(
         return service_name
 
 
-@tracing.traced()
 class ServiceManagementClient(object):
     """Service Management Client."""
 

--- a/google/cloud/forseti/services/inventory/base/cloudasset.py
+++ b/google/cloud/forseti/services/inventory/base/cloudasset.py
@@ -98,12 +98,13 @@ DEFAULT_ASSET_TYPES = [
 
 
 @tracing.trace()
-def load_cloudasset_data(session, config):
+def load_cloudasset_data(session, config, tracer=None):
     """Export asset data from Cloud Asset API and load into storage.
 
     Args:
         session (object): Database session.
         config (object): Inventory configuration on server.
+        tracer (object): OpenCensus tracer.
 
     Returns:
         int: The count of assets imported into the database, or None if there
@@ -130,7 +131,8 @@ def load_cloudasset_data(session, config):
                                                cloudasset_client,
                                                config,
                                                root_id,
-                                               content_type))
+                                               content_type,
+                                               tracer))
 
         for future in concurrent.futures.as_completed(futures):
             temporary_file = ''
@@ -153,7 +155,8 @@ def load_cloudasset_data(session, config):
 
 
 @tracing.trace()
-def _export_assets(cloudasset_client, config, root_id, content_type):
+def _export_assets(cloudasset_client, config, root_id, content_type,
+                   tracer=None):
     """Worker function for exporting assets and downloading dump from GCS.
 
     Args:
@@ -161,6 +164,7 @@ def _export_assets(cloudasset_client, config, root_id, content_type):
         config (object): Inventory configuration on server.
         root_id (str): The name of the parent resource to export assests under.
         content_type (ContentTypes): The content type to export.
+        tracer (object): OpenCensus tracer.
 
     Returns:
         str: The path to the temporary file downloaded from GCS or None on

--- a/google/cloud/forseti/services/inventory/base/cloudasset.py
+++ b/google/cloud/forseti/services/inventory/base/cloudasset.py
@@ -215,6 +215,7 @@ def _export_assets(cloudasset_client, config, root_id, content_type):
         LOGGER.warning('Download of CAI dump from GCS failed: %s', e)
         return None
 
+
 @tracing.trace()
 def _clear_cai_data(session):
     """Clear CAI data from storage.

--- a/google/cloud/forseti/services/inventory/base/cloudasset.py
+++ b/google/cloud/forseti/services/inventory/base/cloudasset.py
@@ -26,6 +26,8 @@ from google.cloud.forseti.common.util import file_loader
 from google.cloud.forseti.common.util import logger
 from google.cloud.forseti.services.inventory.storage import CaiDataAccess
 
+from google.cloud.forseti.common.opencensus import tracing
+
 LOGGER = logger.get_logger(__name__)
 CONTENT_TYPES = ['RESOURCE', 'IAM_POLICY']
 
@@ -96,6 +98,7 @@ DEFAULT_ASSET_TYPES = [
 ]
 
 
+@tracing.trace()
 def load_cloudasset_data(session, config):
     """Export asset data from Cloud Asset API and load into storage.
 
@@ -150,6 +153,7 @@ def load_cloudasset_data(session, config):
     return imported_assets
 
 
+@tracing.trace()
 def _export_assets(cloudasset_client, config, root_id, content_type):
     """Worker function for exporting assets and downloading dump from GCS.
 
@@ -212,7 +216,7 @@ def _export_assets(cloudasset_client, config, root_id, content_type):
         LOGGER.warning('Download of CAI dump from GCS failed: %s', e)
         return None
 
-
+@tracing.trace()
 def _clear_cai_data(session):
     """Clear CAI data from storage.
 

--- a/google/cloud/forseti/services/inventory/base/cloudasset.py
+++ b/google/cloud/forseti/services/inventory/base/cloudasset.py
@@ -22,11 +22,10 @@ from googleapiclient import errors
 
 from google.cloud.forseti.common.gcp_api import cloudasset
 from google.cloud.forseti.common.gcp_api import errors as api_errors
+from google.cloud.forseti.common.opencensus import tracing
 from google.cloud.forseti.common.util import file_loader
 from google.cloud.forseti.common.util import logger
 from google.cloud.forseti.services.inventory.storage import CaiDataAccess
-
-from google.cloud.forseti.common.opencensus import tracing
 
 LOGGER = logger.get_logger(__name__)
 CONTENT_TYPES = ['RESOURCE', 'IAM_POLICY']

--- a/google/cloud/forseti/services/inventory/crawler.py
+++ b/google/cloud/forseti/services/inventory/crawler.py
@@ -335,7 +335,7 @@ def _api_client_factory(storage, config, parallel, tracer=None):
     if config.get_cai_enabled():
         # TODO: When CAI supports resource exclusion, update the following
         #       method to handle resource exclusion during export time.
-        asset_count = cloudasset.load_cloudasset_data(storage.session, config, tracer)
+        asset_count = cloudasset.load_cloudasset_data(storage.session, config)
         LOGGER.info('%s total assets loaded from Cloud Asset data.',
                     asset_count)
 

--- a/google/cloud/forseti/services/inventory/crawler.py
+++ b/google/cloud/forseti/services/inventory/crawler.py
@@ -315,7 +315,7 @@ class ParallelCrawler(Crawler):
 
 
 @tracing.trace()
-def _api_client_factory(storage, config, parallel, tracer=None):
+def _api_client_factory(storage, config, parallel):
     """Creates the proper initialized API client based on the configuration.
 
     Args:

--- a/google/cloud/forseti/services/inventory/crawler.py
+++ b/google/cloud/forseti/services/inventory/crawler.py
@@ -422,7 +422,7 @@ def run_crawler(storage,
         LOGGER.info('SQLite used, disabling parallel threads.')
         parallel = False
 
-    client = _api_client_factory(storage, config, parallel, tracer)
+    client = _api_client_factory(storage, config, parallel)
     crawler_impl = _crawler_factory(storage, progresser, client, parallel)
     resource = _root_resource_factory(config, client)
     progresser = crawler_impl.run(resource)

--- a/google/cloud/forseti/services/inventory/crawler.py
+++ b/google/cloud/forseti/services/inventory/crawler.py
@@ -314,7 +314,8 @@ class ParallelCrawler(Crawler):
             raise
 
 
-def _api_client_factory(storage, config, parallel):
+@tracing.trace()
+def _api_client_factory(storage, config, parallel, tracer=None):
     """Creates the proper initialized API client based on the configuration.
 
     Args:


### PR DESCRIPTION
Add spans for CAI and API operations so that we can get a more complete & detailed picture of what is happening in the Inventory trace.  The screenshot below shows some missing gaps being filled, but I am not unable to see the following spans despite them being called. Would appreciate any suggestions.

#1: span for `_export_asset()` is not shown

#2: span for `BigQueryClient.get_tables()` is not shown. 

#3: Spans for all the methods in `ServiceManagementClient` class are not shown.

For the API methods, I am not adding spans on the actual request call, but rather the higher level methods.  I would expect span for this would work.

![image](https://user-images.githubusercontent.com/6977544/63241187-96148e80-c207-11e9-9c40-80202d2932e1.png)
