### PR TITLE
Do not inactivate findings that are already inactive

### DIFF
--- a/google/cloud/forseti/notifier/notifiers/cscc_notifier.py
+++ b/google/cloud/forseti/notifier/notifiers/cscc_notifier.py
@@ -163,7 +163,7 @@ class CsccNotifier(object):
     def find_inactive_findings(new_findings, findings_in_cscc):
         """Finds the currently ACTIVE findings
            that do not correspond to the latest scanner run
-           and updates their statesto inactive.
+           and updates their states to inactive.
 
         Args:
             new_findings (list): Latest violations that are transformed to
@@ -188,8 +188,10 @@ class CsccNotifier(object):
             finding_id = finding_list[0]
             to_be_updated_finding = finding_list[1]
 
-            if (finding_id not in new_findings_map and
-                    to_be_updated_finding['state'] == 'ACTIVE'):
+            if to_be_updated_finding['state'] == 'INACTIVE':
+                continue
+
+            if finding_id not in new_findings_map:
                 to_be_updated_finding['state'] = 'INACTIVE'
                 current_time = date_time.get_utc_now_datetime()
                 actual_time = current_time.strftime(

--- a/google/cloud/forseti/notifier/notifiers/cscc_notifier.py
+++ b/google/cloud/forseti/notifier/notifiers/cscc_notifier.py
@@ -161,8 +161,9 @@ class CsccNotifier(object):
 
     @staticmethod
     def find_inactive_findings(new_findings, findings_in_cscc):
-        """Finds the findings that does not correspond to the latest scanner run
-           and updates it's state to inactive.
+        """Finds the currently ACTIVE findings
+           that do not correspond to the latest scanner run
+           and updates their statesto inactive.
 
         Args:
             new_findings (list): Latest violations that are transformed to
@@ -171,7 +172,7 @@ class CsccNotifier(object):
                 corresponds to the previous scanner run.
 
         Returns:
-            list: Findings whose state has been marked as 'INACTIVE'.
+            list: Findings to be marked as 'INACTIVE'.
         """
 
         inactive_findings = []
@@ -187,7 +188,8 @@ class CsccNotifier(object):
             finding_id = finding_list[0]
             to_be_updated_finding = finding_list[1]
 
-            if finding_id not in new_findings_map:
+            if (finding_id not in new_findings_map and
+                    to_be_updated_finding['state'] == 'ACTIVE'):
                 to_be_updated_finding['state'] = 'INACTIVE'
                 current_time = date_time.get_utc_now_datetime()
                 actual_time = current_time.strftime(

--- a/tests/notifier/notifiers/cscc_notifier_test.py
+++ b/tests/notifier/notifiers/cscc_notifier_test.py
@@ -158,7 +158,25 @@ class CsccNotifierTest(scanner_base_db.ScannerBaseDbTestCase):
                                                    'violation_data': '{"bucket": "isthispublic", "domain": "", "email": "", "entity": "allUsers", "full_name": "organization/123/project/inventoryscanner/bucket/isthispublic/", "project_id": "inventoryscanner", "role": "READER"}',
                                                    'resource_id': 'isthispublic',
                                                    'scanner_index_id': 1551913369403591,
-                                                   'resource_type': 'bucket'}}]]
+                                                   'resource_type': 'bucket'}}],
+                            ['hij',
+                            {'category': 'BUCKET_VIOLATION',
+                             'resource_name': 'organization/123/project/inventoryscanner/bucket/nolongerpublic/',
+                             'name': 'organizations/123/sources/560/findings/hij',
+                             'parent': 'organizations/123/sources/560',
+                             'event_time': '2019-03-12T16:06:19Z',
+                             'state': 'INACTIVE',
+                             'source_properties': {'source': 'FORSETI',
+                                                   'rule_name': 'Bucket acls rule to search for public buckets',
+                                                   'inventory_index_id': 789,
+                                                   'resource_data': '{"bucket": "nolongerpublic", "entity": "allUsers", "id": "nolongerpublic/allUsers", "role": "READER"}',
+                                                   'db_source': 'table:violations/id:94953',
+                                                   'rule_index': 0,
+                                                   'violation_data': '{"bucket": "nolongerpublic", "domain": "", "email": "", "entity": "allUsers", "full_name": "organization/123/project/inventoryscanner/bucket/nolongerpublic/", "project_id": "inventoryscanner", "role": "READER"}',
+                                                   'resource_id': 'nolongerpublic',
+                                                   'scanner_index_id': 1551913369403591,
+                                                   'resource_type': 'bucket'}}]
+                             ]
 
         EXPECTED_INACTIVE_FINDINGS = [['ffe',
                             {'category': 'BUCKET_VIOLATION',


### PR DESCRIPTION
- [x] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [x] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [x] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [x] My PR has been functionally tested.
- [x] All of the [tests](https://forsetisecurity.org/docs/latest/develop/dev/testing.html) pass
- [] I have submitted a corresponding PR in the [Forseti Terraform module](https://github.com/forseti-security/terraform-google-forseti) (if applicable).

Currently the cscc notifiers try to inactivate outdated findings that are already INACTIVE again.

This PR resolves this issue and has 2 benefits:
1. Reduce time taken for CSCC Notifier run - it saves 40 mins in my testing org with 5k inactive findings)
2. Reduce number of Cloud SCC API calls - Before the change there was "Resource has been exhausted (e.g. check quota)." error from Cloud SCC API calls 