### PR TITLE
Add slack notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,5 +39,8 @@ after_success:
 
 notifications:
   slack:
+    on_failure: always
+    on_pull_requests: false
+    on_success: change
     rooms:
       secure: FARoc4RRj7/lXoHerXFVtonb6G5O2QspYvRQnx+R8T0J+Nt4vk5YtwMY+Dve3pYmbY+SOyrKaGcqiPmltuV14T45XZM8QnNBZaC4tXImz6hfSuDoC+NcFZ7J9BQ39qJITrgqz4v5CFOUxCT6rTDe5qZJr7/kBhjcpEgRTWf+AGg7Up1+ZbmgIDltEzEw9c/EYF/KlxRnhIW6Ku6SAErLhdjCPosqsrcgZurFkKAQ27yDRBtdEalRhzzXfDjb2vo614WCmatK9FX7ry5Jp0Pw2piq++XMRLohj9IQ+17LeJOsff/57d1p3dV6AQzxnugPNnzePuo9lww59rvJocPc/6U/xujtLDCRxr9gS6m8Up18d6Guj9kln9E48HZB2VtKgJ6zb0RbzK331Zt0mEoQEAf83Ll2ItuMxdrjQT5cnRgy2seVrsWAFfktA1BIMxaHYsAcGvsW0LqjYv+X4C4zMkhr4clg/7mLpeScwS8kO1mYjCHdfkXs31dE4Kp5Q9umxsB6Lky6otpHjYo6nfZ6CAPnZz38elg9dOoNlNuzZQ2g5HY7cL87Pv5Fg8vv2XagnJG7sg7bCPlv8L8YD8ZevVSFxYYKN2cH21nnx0ElTgDEgDhTwp7x5sOypsN3n4R6r/6mgDrIg4d1w9oXAu7DiUmFPcZFqbSbZA7ycbpAAjI=

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,8 @@ script:
 after_success:
   # Collect codecov results.
   - docker -l error exec -it build /bin/bash -c "bash <(curl -s https://codecov.io/bash)"
+
+notifications:
+  slack:
+    rooms:
+      secure: FARoc4RRj7/lXoHerXFVtonb6G5O2QspYvRQnx+R8T0J+Nt4vk5YtwMY+Dve3pYmbY+SOyrKaGcqiPmltuV14T45XZM8QnNBZaC4tXImz6hfSuDoC+NcFZ7J9BQ39qJITrgqz4v5CFOUxCT6rTDe5qZJr7/kBhjcpEgRTWf+AGg7Up1+ZbmgIDltEzEw9c/EYF/KlxRnhIW6Ku6SAErLhdjCPosqsrcgZurFkKAQ27yDRBtdEalRhzzXfDjb2vo614WCmatK9FX7ry5Jp0Pw2piq++XMRLohj9IQ+17LeJOsff/57d1p3dV6AQzxnugPNnzePuo9lww59rvJocPc/6U/xujtLDCRxr9gS6m8Up18d6Guj9kln9E48HZB2VtKgJ6zb0RbzK331Zt0mEoQEAf83Ll2ItuMxdrjQT5cnRgy2seVrsWAFfktA1BIMxaHYsAcGvsW0LqjYv+X4C4zMkhr4clg/7mLpeScwS8kO1mYjCHdfkXs31dE4Kp5Q9umxsB6Lky6otpHjYo6nfZ6CAPnZz38elg9dOoNlNuzZQ2g5HY7cL87Pv5Fg8vv2XagnJG7sg7bCPlv8L8YD8ZevVSFxYYKN2cH21nnx0ElTgDEgDhTwp7x5sOypsN3n4R6r/6mgDrIg4d1w9oXAu7DiUmFPcZFqbSbZA7ycbpAAjI=


### PR DESCRIPTION
Updated the travis config to notify a private Slack channel when the Forseti build fails and when the build changes status (i.e. gets fixed). This will be done for all branches; Travis does not provide the ability to control this.