### PR TITLE
Add policy library sync

### DIFF
--- a/deployment-templates/compute-engine/server/forseti-instance-server.py
+++ b/deployment-templates/compute-engine/server/forseti-instance-server.py
@@ -246,8 +246,8 @@ gsutil cp gs://{scanner_bucket}/configs/forseti_conf_server.yaml {forseti_server
 gsutil cp -r gs://{scanner_bucket}/rules {forseti_home}/
 
 # Download the Newest Config Validator constraints from GCS
-rm -rf {forseti_home}/policy-library
-gsutil cp -r gs://{scanner_bucket}/policy-library {forseti_home}/
+rm -rf {policy_library_home}
+gsutil cp -r gs://{scanner_bucket}/policy-library {policy_library_home}/
 
 # Start Forseti service depends on vars defined above.
 bash ./install/gcp/scripts/initialize_forseti_services.sh
@@ -305,6 +305,7 @@ echo "Execution of startup script finished"
 
     # Set ownership for Forseti conf and rules dirs
     forseti_home=FORSETI_HOME,
+    policy_library_home=POLICY_LIBRARY_HOME,
 
     # Download the Forseti conf and rules.
     scanner_bucket=SCANNER_BUCKET,

--- a/deployment-templates/compute-engine/server/forseti-instance-server.py
+++ b/deployment-templates/compute-engine/server/forseti-instance-server.py
@@ -43,6 +43,7 @@ def GenerateConfig(context):
     """Generate configuration."""
 
     FORSETI_HOME = '$USER_HOME/forseti-security'
+    POLICY_LIBRARY_HOME = '$USER_HOME/policy-library'
 
     DOWNLOAD_FORSETI = (
         "git clone {src_path}.git".format(
@@ -94,8 +95,10 @@ git checkout ${{latest_version[0]}}"""
     EXPORT_FORSETI_VARS = (
         'export FORSETI_HOME={forseti_home}\n'
         'export FORSETI_SERVER_CONF={forseti_server_conf}\n'
+        'export POLICY_LIBRARY_HOME={policy_library_home}\n'
         ).format(forseti_home=FORSETI_HOME,
-                 forseti_server_conf=FORSETI_SERVER_CONF)
+                 forseti_server_conf=FORSETI_SERVER_CONF,
+                 policy_library_home=POLICY_LIBRARY_HOME)
 
     RUN_FREQUENCY = context.properties['run-frequency']
 

--- a/install/gcp/scripts/initialize_forseti_services.sh
+++ b/install/gcp/scripts/initialize_forseti_services.sh
@@ -45,8 +45,7 @@ CONFIG_VALIDATOR_COMMAND+=" --policyPath='${POLICY_LIBRARY_HOME}/policy-library/
 CONFIG_VALIDATOR_COMMAND+=" --policyLibraryPath='${POLICY_LIBRARY_HOME}/policy-library/lib'"
 CONFIG_VALIDATOR_COMMAND+=" -port=50052"
 
-POLICY_LIBRARY_SYNC_COMMAND="sudo docker"
-POLICY_LIBRARY_SYNC_COMMAND+=" run -d"
+POLICY_LIBRARY_SYNC_COMMAND="$(which docker) run -d"
 POLICY_LIBRARY_SYNC_COMMAND+=" --log-driver=gcplogs"
 POLICY_LIBRARY_SYNC_COMMAND+=" --log-opt gcp-log-cmd=true"
 POLICY_LIBRARY_SYNC_COMMAND+=" --log-opt labels=git-sync"
@@ -134,8 +133,8 @@ WantedBy=multi-user.target
 EOF
 )"
 if [ "$POLICY_LIBRARY_SYNC_ENABLED" == "true" ]; then
-  echo "$POLICY_LIBRARY_SYNC_SERVICE" > /tmp/policy_library_sync.service
-  sudo mv /tmp/policy_library_sync.service /lib/systemd/system/policy_library_sync.service
+  echo "$POLICY_LIBRARY_SYNC_SERVICE" > /tmp/policy-library-sync.service
+  sudo mv /tmp/policy-library-sync.service /lib/systemd/system/policy-library-sync.service
 fi
 
 # Define a foreground runner. This runner will start the CloudSQL
@@ -157,6 +156,7 @@ echo ""
 echo "    systemctl start cloudsqlproxy"
 echo "    systemctl start forseti"
 echo "    systemctl start config-validator"
+echo "    systemctl start policy-library-sync"
 echo ""
 echo "Additionally, the Forseti server can be run in the foreground by using"
 echo "the foreground runner script: /usr/bin/forseti-foreground.sh"

--- a/install/gcp/scripts/initialize_forseti_services.sh
+++ b/install/gcp/scripts/initialize_forseti_services.sh
@@ -126,7 +126,6 @@ POLICY_LIBRARY_SYNC_SERVICE="$(cat << EOF
 [Unit]
 Description=Policy Library Sync
 [Service]
-User=ubuntu
 ExecStart=$POLICY_LIBRARY_SYNC_COMMAND
 [Install]
 WantedBy=multi-user.target

--- a/install/gcp/scripts/initialize_forseti_services.sh
+++ b/install/gcp/scripts/initialize_forseti_services.sh
@@ -41,9 +41,33 @@ FORSETI_COMMAND+=" --config_file_path ${FORSETI_SERVER_CONF}"
 FORSETI_COMMAND+=" --services ${FORSETI_SERVICES}"
 
 CONFIG_VALIDATOR_COMMAND="${FORSETI_HOME}/external-dependencies/config-validator/ConfigValidatorRPCServer"
-CONFIG_VALIDATOR_COMMAND+=" --policyPath='${FORSETI_HOME}/policy-library/policies'"
-CONFIG_VALIDATOR_COMMAND+=" --policyLibraryPath='${FORSETI_HOME}/policy-library/lib'"
+CONFIG_VALIDATOR_COMMAND+=" --policyPath='${POLICY_LIBRARY_HOME}/policy-library/policies'"
+CONFIG_VALIDATOR_COMMAND+=" --policyLibraryPath='${POLICY_LIBRARY_HOME}/policy-library/lib'"
 CONFIG_VALIDATOR_COMMAND+=" -port=50052"
+
+POLICY_LIBRARY_SYNC_COMMAND="sudo docker"
+POLICY_LIBRARY_SYNC_COMMAND+=" run -d"
+POLICY_LIBRARY_SYNC_COMMAND+=" --log-driver=gcplogs"
+POLICY_LIBRARY_SYNC_COMMAND+=" --log-opt gcp-log-cmd=true"
+POLICY_LIBRARY_SYNC_COMMAND+=" --log-opt labels=git-sync"
+POLICY_LIBRARY_SYNC_COMMAND+=" -v ${POLICY_LIBRARY_HOME}:/tmp/git"
+POLICY_LIBRARY_SYNC_COMMAND+=" -v /etc/git-secret:/etc/git-secret"
+POLICY_LIBRARY_SYNC_COMMAND+=" k8s.gcr.io/git-sync:${POLICY_LIBRARY_SYNC_GIT_SYNC_TAG}"
+POLICY_LIBRARY_SYNC_COMMAND+=" --branch=master"
+POLICY_LIBRARY_SYNC_COMMAND+=" --dest=policy-library"
+POLICY_LIBRARY_SYNC_COMMAND+=" --max-sync-failures=-1"
+POLICY_LIBRARY_SYNC_COMMAND+=" --repo=${POLICY_LIBRARY_HOME_REPOSITORY_URL}"
+POLICY_LIBRARY_SYNC_COMMAND+=" --wait=30"
+
+# If the SSH file is present, tell git-sync to use SSH to connect to the repo
+if [ -e "/etc/git-secret/ssh" ]; then
+  POLICY_LIBRARY_SYNC_COMMAND+=" --ssh"
+fi
+
+# If the known_hosts file is NOT present, tell git-sync to not check known hosts
+if ! [ -e "/etc/git-secret/known_hosts" ]; then
+  POLICY_LIBRARY_SYNC_COMMAND+=" --ssh-known-hosts=false"
+fi
 
 # Update the permission of the config validator.
 sudo chmod ugo+x ${FORSETI_HOME}/external-dependencies/config-validator/ConfigValidatorRPCServer
@@ -98,6 +122,21 @@ EOF
 echo "$SQL_PROXY_SERVICE" > /tmp/cloudsqlproxy.service
 sudo mv /tmp/cloudsqlproxy.service /lib/systemd/system/cloudsqlproxy.service
 
+# Policy Library Sync Service
+POLICY_LIBRARY_SYNC_SERVICE="$(cat << EOF
+[Unit]
+Description=Policy Library Sync
+[Service]
+User=ubuntu
+ExecStart=$POLICY_LIBRARY_SYNC_COMMAND
+[Install]
+WantedBy=multi-user.target
+EOF
+)"
+if [ "$POLICY_LIBRARY_SYNC_ENABLED" == "true" ]; then
+  echo "$POLICY_LIBRARY_SYNC_SERVICE" > /tmp/policy_library_sync.service
+  sudo mv /tmp/policy_library_sync.service /lib/systemd/system/policy_library_sync.service
+fi
 
 # Define a foreground runner. This runner will start the CloudSQL
 # proxy and block on the Forseti API server.

--- a/install/gcp/scripts/initialize_forseti_services.sh
+++ b/install/gcp/scripts/initialize_forseti_services.sh
@@ -55,7 +55,7 @@ POLICY_LIBRARY_SYNC_COMMAND+=" k8s.gcr.io/git-sync:${POLICY_LIBRARY_SYNC_GIT_SYN
 POLICY_LIBRARY_SYNC_COMMAND+=" --branch=master"
 POLICY_LIBRARY_SYNC_COMMAND+=" --dest=policy-library"
 POLICY_LIBRARY_SYNC_COMMAND+=" --max-sync-failures=-1"
-POLICY_LIBRARY_SYNC_COMMAND+=" --repo=${POLICY_LIBRARY_HOME_REPOSITORY_URL}"
+POLICY_LIBRARY_SYNC_COMMAND+=" --repo=${POLICY_LIBRARY_REPOSITORY_URL}"
 POLICY_LIBRARY_SYNC_COMMAND+=" --wait=30"
 
 # If the SSH file is present, tell git-sync to use SSH to connect to the repo
@@ -154,8 +154,8 @@ echo "immediately by running the following:"
 echo ""
 echo "    systemctl start cloudsqlproxy"
 echo "    systemctl start forseti"
-echo "    systemctl start config-validator"
 echo "    systemctl start policy-library-sync"
+echo "    systemctl start config-validator"
 echo ""
 echo "Additionally, the Forseti server can be run in the foreground by using"
 echo "the foreground runner script: /usr/bin/forseti-foreground.sh"

--- a/install/gcp/scripts/run_forseti.sh
+++ b/install/gcp/scripts/run_forseti.sh
@@ -26,7 +26,9 @@ sudo gsutil cp gs://${SCANNER_BUCKET}/configs/forseti_conf_server.yaml ${FORSETI
 sudo gsutil cp -r gs://${SCANNER_BUCKET}/rules ${FORSETI_HOME}/
 
 # Download the Newest Config Validator constraints from GCS.
-sudo gsutil cp -r gs://${SCANNER_BUCKET}/policy-library ${POLICY_LIBRARY_HOME}/
+if [ "$POLICY_LIBRARY_SYNC_ENABLED" != "true" ]; then
+  sudo gsutil cp -r gs://${SCANNER_BUCKET}/policy-library ${POLICY_LIBRARY_HOME}/
+fi
 
 # Restart the config validator service to pick up the latest policy.
 sudo systemctl restart config-validator

--- a/install/gcp/scripts/run_forseti.sh
+++ b/install/gcp/scripts/run_forseti.sh
@@ -26,8 +26,7 @@ sudo gsutil cp gs://${SCANNER_BUCKET}/configs/forseti_conf_server.yaml ${FORSETI
 sudo gsutil cp -r gs://${SCANNER_BUCKET}/rules ${FORSETI_HOME}/
 
 # Download the Newest Config Validator constraints from GCS.
-sudo rm -rf ${FORSETI_HOME}/policy-library
-sudo gsutil cp -r gs://${SCANNER_BUCKET}/policy-library ${FORSETI_HOME}/
+sudo gsutil cp -r gs://${SCANNER_BUCKET}/policy-library ${POLICY_LIBRARY_HOME}/
 
 # Restart the config validator service to pick up the latest policy.
 sudo systemctl restart config-validator


### PR DESCRIPTION
Addresses #3155. These changes help to support the Terraform changes (https://github.com/forseti-security/terraform-google-forseti/issues/238) to allow users to sync the policy library from a public/private Git repo as an alternative to manually copying the files to GCS.