### PR TITLE
Feature/fix init services script

### DIFF
--- a/deployment-templates/compute-engine/server/forseti-instance-server.py
+++ b/deployment-templates/compute-engine/server/forseti-instance-server.py
@@ -250,6 +250,7 @@ gsutil cp -r gs://{scanner_bucket}/rules {forseti_home}/
 
 # Download the Newest Config Validator constraints from GCS
 rm -rf {policy_library_home}
+sudo mkdir -m 777 ${policy_library_home}
 gsutil cp -r gs://{scanner_bucket}/policy-library {policy_library_home}/
 
 # Start Forseti service depends on vars defined above.

--- a/deployment-templates/compute-engine/server/forseti-instance-server.py
+++ b/deployment-templates/compute-engine/server/forseti-instance-server.py
@@ -250,7 +250,7 @@ gsutil cp -r gs://{scanner_bucket}/rules {forseti_home}/
 
 # Download the Newest Config Validator constraints from GCS
 rm -rf {policy_library_home}
-sudo mkdir -m 777 ${policy_library_home}
+sudo mkdir -m 777 {policy_library_home}
 gsutil cp -r gs://{scanner_bucket}/policy-library {policy_library_home}/
 
 # Start Forseti service depends on vars defined above.

--- a/deployment-templates/compute-engine/server/forseti-instance-server.py
+++ b/deployment-templates/compute-engine/server/forseti-instance-server.py
@@ -44,6 +44,7 @@ def GenerateConfig(context):
 
     FORSETI_HOME = '$USER_HOME/forseti-security'
     POLICY_LIBRARY_HOME = '$USER_HOME/policy-library'
+    POLICY_LIBRARY_SYNC_ENABLED = 'false'
 
     DOWNLOAD_FORSETI = (
         "git clone {src_path}.git".format(
@@ -96,9 +97,11 @@ git checkout ${{latest_version[0]}}"""
         'export FORSETI_HOME={forseti_home}\n'
         'export FORSETI_SERVER_CONF={forseti_server_conf}\n'
         'export POLICY_LIBRARY_HOME={policy_library_home}\n'
+        'export POLICY_LIBRARY_SYNC_ENABLED={policy_library_sync_enabled}\n'
         ).format(forseti_home=FORSETI_HOME,
                  forseti_server_conf=FORSETI_SERVER_CONF,
-                 policy_library_home=POLICY_LIBRARY_HOME)
+                 policy_library_home=POLICY_LIBRARY_HOME,
+                 policy_library_sync_enabled=POLICY_LIBRARY_SYNC_ENABLED)
 
     RUN_FREQUENCY = context.properties['run-frequency']
 


### PR DESCRIPTION
The Policy Library Sync changes were causing an issue with the initialize Forseti services script. The absence of the POLICY_LIBRARY_SYNC_ENABLED environment variable was causing the script to terminate early, and the necessary services were not being configured.