### PR TITLE
Allow specification of config-validator endpoint via env var

### DIFF
--- a/google/cloud/forseti/scanner/scanners/config_validator_util/validator_client.py
+++ b/google/cloud/forseti/scanner/scanners/config_validator_util/validator_client.py
@@ -16,6 +16,7 @@
 
 
 from builtins import object
+import os
 import sys
 
 import grpc
@@ -35,7 +36,7 @@ LOGGER = logger.get_logger(__name__)
 class ValidatorClient(object):
     """Validator client."""
 
-    DEFAULT_ENDPOINT = 'localhost:50052'
+    DEFAULT_ENDPOINT = os.getenv('CONFIG_VALIDATOR_ENDPOINT', 'localhost:50052')
 
     def __init__(self, endpoint=DEFAULT_ENDPOINT):
         """Initialize


### PR DESCRIPTION
In order to support _git-sync_ for _config-validator_ on GKE, _config-validator_ must be restarted in order to account for new, updated, or deleted policies and constraints.  This means that the pod in which _config-validator_ runs must be restarted (really it gets deleted).

In order to mitigate the impact to the container running the forseti-server, the _config-validator_ will need to run in a separate pod.  This change allows the specification of the _config-validator_ endpoint via environment variable.