### PR TITLE
Filter out bug-fix versions from doc build.

### DIFF
--- a/scripts/sync_latest_version.sh
+++ b/scripts/sync_latest_version.sh
@@ -44,7 +44,7 @@ function main() {
     doc_versions="$(uniq_major_minor_filter "$(ls _docs)")"
 
     if [ -z "${doc_versions}" ]; then
-        err "The _docs/ directory is not versioned properly. Please initialize 
+        err "The _docs/ directory is not versioned properly. Please initialize
             with at least one version."
         exit -1
     fi

--- a/scripts/sync_latest_version.sh
+++ b/scripts/sync_latest_version.sh
@@ -35,15 +35,16 @@ function uniq_major_minor_filter() {
 }
 
 function main() {
-    local all_release_tags releases doc_versions
+    local all_release_tags all_major_release_tags releases doc_versions
     all_release_tags="$(git tag -l v*.*)"
+    all_major_minor_release_tags="$(uniq_major_minor_filter "${all_release_tags}")"
+
     # sed trims this list to 10.
-    all_supported_release_tags="$(echo "${all_release_tags}" | sort -Vr | cut -d "." -f1-2 | sed '1,10!d')"
-    releases="$(uniq_major_minor_filter "${all_supported_release_tags}")"
+    releases="$(echo "${all_major_minor_release_tags}" | sort -Vr | cut -d "." -f1-2 | sed '1,10!d')"
     doc_versions="$(uniq_major_minor_filter "$(ls _docs)")"
 
     if [ -z "${doc_versions}" ]; then
-        err "The _docs/ directory is not versioned properly. Please initialize 
+        err "The _docs/ directory is not versioned properly. Please initialize
             with at least one version."
         exit -1
     fi

--- a/scripts/sync_latest_version.sh
+++ b/scripts/sync_latest_version.sh
@@ -44,7 +44,7 @@ function main() {
     doc_versions="$(uniq_major_minor_filter "$(ls _docs)")"
 
     if [ -z "${doc_versions}" ]; then
-        err "The _docs/ directory is not versioned properly. Please initialize
+        err "The _docs/ directory is not versioned properly. Please initialize 
             with at least one version."
         exit -1
     fi

--- a/scripts/sync_latest_version.sh
+++ b/scripts/sync_latest_version.sh
@@ -35,7 +35,7 @@ function uniq_major_minor_filter() {
 }
 
 function main() {
-    local all_release_tags all_major_release_tags releases doc_versions
+    local all_release_tags all_major_minor_release_tags releases doc_versions
     all_release_tags="$(git tag -l v*.*)"
     all_major_minor_release_tags="$(uniq_major_minor_filter "${all_release_tags}")"
 


### PR DESCRIPTION
We only support building documentations for `x.y` changes in `x.y.z` semantic versioning.  i.e. we don't build docs for patch or bug-fix version changes (`.z`).

This makes #3091 work correctly by filtering out the patch or bug-fix versions.

This is the output:
```
releases
v2.20 v2.19 v2.18 v2.17 v2.16 v2.15 v2.14 v2.13 v2.12 v2.11
--------------
doc_versions
v2.10 v2.11 v2.12 v2.13 v2.14 v2.15 v2.16 v2.17 v2.18 v2.19 v2.9
```