### PR TITLE
Fix db_migrator.py script for customer Forseti DB name

### DIFF
--- a/install/gcp/upgrade_tools/db_migrator.py
+++ b/install/gcp/upgrade_tools/db_migrator.py
@@ -17,6 +17,7 @@
 from __future__ import print_function
 
 from builtins import object
+import os
 import sys
 
 # Importing migrate.changeset adds some new methods to existing SQLAlchemy
@@ -30,8 +31,8 @@ import google.cloud.forseti.services.dao as general_dao
 
 from google.cloud.forseti.common.util import logger
 
-
-DEFAULT_DB_CONN_STR = 'mysql+pymysql://root@127.0.0.1:3306/forseti_security'
+DB_NAME = os.environ.get('FORSETI_DB_NAME', 'forseti_security')
+DEFAULT_DB_CONN_STR = f'mysql+pymysql://root@127.0.0.1:3306/{DB_NAME}'
 LOGGER = logger.get_logger(__name__)
 
 


### PR DESCRIPTION
Updated the db_migrator.py script by using the FORSETI_DB_NAME environment variable for the Forseti database name. This is set via Terraform and the startup script. Will have some additional PRs for the GKE changes.

Addresses #2938 for GCE installations.