### PR TITLE
Module source argument needs a double slash

### DIFF
--- a/_docs/_latest/setup/real-time-enforcer.md
+++ b/_docs/_latest/setup/real-time-enforcer.md
@@ -40,19 +40,19 @@ module "forseti" {
 }
 
 module "real_time_enforcer_roles" {
-   source = "terraform-google-modules/forseti/google/modules/real_time_enforcer_roles"
+   source = "terraform-google-modules/forseti/google//modules/real_time_enforcer_roles"
    org_id = "${var.org_id}"
    suffix = "${module.forseti.suffix}"
 }
 
 module "real_time_enforcer_organization_sink" {
-  source            = "terraform-google-modules/forseti/google/modules/real_time_enforcer_organization_sink"
+  source            = "terraform-google-modules/forseti/google//modules/real_time_enforcer_organization_sink"
   pubsub_project_id = "${var.project_id}"
   org_id            = "${var.org_id}"
 }
 
  module "real_time_enforcer" {
-   source                     = "terraform-google-modules/forseti/google/modules/real_time_enforcer"
+   source                     = "terraform-google-modules/forseti/google//modules/real_time_enforcer"
    project_id                 = "${var.project_id}"
    org_id                     = "${var.org_id}"
    enforcer_instance_metadata = "${var.instance_metadata}"


### PR DESCRIPTION
Without the double slash I get errors, eg:

```
Error: Module not found

The module address
"terraform-google-modules/forseti/google/modules/real_time_enforcer" could not
be resolved.
```

Replacing `google/modules` with `google//modules` resolves the issue.

Thanks for opening a Pull Request!

Here's a handy checklist to ensure your PR goes smoothly.

- [x] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [x] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [x] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [x] My PR has been functionally tested.
- [ ] All of the [tests](https://forsetisecurity.org/docs/latest/develop/dev/testing.html) pass
- [ ] I have submitted a corresponding PR in the [Forseti Terraform module](https://github.com/forseti-security/terraform-google-forseti) (if applicable).

These guidelines and more can be found in our [contributing guidelines](https://github.com/forseti-security/forseti-security/blob/dev/.github/CONTRIBUTING.md).
