### PR TITLE
Minor ForsetiSecurity.org Website changes

### DIFF
--- a/_docs/_latest/setup/forseti-on-gke.md
+++ b/_docs/_latest/setup/forseti-on-gke.md
@@ -371,4 +371,4 @@ terraform state rm module.forseti-on-gke-new-gke-cluster.module.vpc.google_compu
 There are a few things you can do.
 1. Run `terraform apply` or `terraform destroy` again to see if the error occurs repeatedly.
 2. Open an issue against the [Terraform Google Forseti](https://github.com/forseti-security/terraform-google-forseti/issues) module
-3. Post an issue in our [Slack Channel](https://forsetisecurity.slack.com/join/shared_invite/enQtNDIyMzg4Nzg1NjcxLTJhYjI1YzY0MDg4YjRhMDhhZTMwZTg0MWExZjU1MTNiNWFmMmFlMWQ0MmI3OTE1MzczZTMwNTEzNDZiNDY3NTY).  We'll be happy to try and help!
+3. Post an issue in our [Slack Channel](https://forsetisecurity.slack.com/join/shared_invite/enQtNDIyMzg4Nzg1NjcxLTM1NTUzZmM2ODVmNzE5MWEwYzAwNjUxMjVkZjhmYWZiOGZjMjY3ZjllNDlkYjk1OGU4MTVhZGM4NzgyZjZhNTE).  We'll be happy to try and help!

--- a/_docs/_latest/setup/migrate.md
+++ b/_docs/_latest/setup/migrate.md
@@ -11,7 +11,7 @@ deprecated Python Installer to the new Terraform module.
 If you have any
 questions about this process, please contact us by
 [email](mailto:discuss@forsetisecurity.org) or on
-[Slack](https://forsetisecurity.slack.com/).
+[Slack](https://forsetisecurity.slack.com/join/shared_invite/enQtNDIyMzg4Nzg1NjcxLTM1NTUzZmM2ODVmNzE5MWEwYzAwNjUxMjVkZjhmYWZiOGZjMjY3ZjllNDlkYjk1OGU4MTVhZGM4NzgyZjZhNTE).
 
 ---
 
@@ -142,7 +142,7 @@ Import the existing resources to the Terraform state, replacing the
 uppercase values with the aforementioned values:
 
 ```sh
-./import.sh -m forseti -o ORG_ID -p PROJECT_ID -r RESOURCE_NAME_SUFFIX
+./import.sh -m MODULE_LOCAL_NAME -o ORG_ID -p PROJECT_ID -s RESOURCE_NAME_SUFFIX -z GCE_ZONE [-n NETWORK_PROJECT_ID]
 ```
 
 Observe the expected Terraform changes

--- a/_docs/v2.21/setup/forseti-on-gke.md
+++ b/_docs/v2.21/setup/forseti-on-gke.md
@@ -371,4 +371,4 @@ terraform state rm module.forseti-on-gke-new-gke-cluster.module.vpc.google_compu
 There are a few things you can do.
 1. Run `terraform apply` or `terraform destroy` again to see if the error occurs repeatedly.
 2. Open an issue against the [Terraform Google Forseti](https://github.com/forseti-security/terraform-google-forseti/issues) module
-3. Post an issue in our [Slack Channel](https://forsetisecurity.slack.com/join/shared_invite/enQtNDIyMzg4Nzg1NjcxLTJhYjI1YzY0MDg4YjRhMDhhZTMwZTg0MWExZjU1MTNiNWFmMmFlMWQ0MmI3OTE1MzczZTMwNTEzNDZiNDY3NTY).  We'll be happy to try and help!
+3. Post an issue in our [Slack Channel](https://forsetisecurity.slack.com/join/shared_invite/enQtNDIyMzg4Nzg1NjcxLTM1NTUzZmM2ODVmNzE5MWEwYzAwNjUxMjVkZjhmYWZiOGZjMjY3ZjllNDlkYjk1OGU4MTVhZGM4NzgyZjZhNTE).  We'll be happy to try and help!

--- a/_docs/v2.21/setup/migrate.md
+++ b/_docs/v2.21/setup/migrate.md
@@ -11,7 +11,7 @@ deprecated Python Installer to the new Terraform module.
 If you have any
 questions about this process, please contact us by
 [email](mailto:discuss@forsetisecurity.org) or on
-[Slack](https://forsetisecurity.slack.com/).
+[Slack](https://forsetisecurity.slack.com/join/shared_invite/enQtNDIyMzg4Nzg1NjcxLTM1NTUzZmM2ODVmNzE5MWEwYzAwNjUxMjVkZjhmYWZiOGZjMjY3ZjllNDlkYjk1OGU4MTVhZGM4NzgyZjZhNTE).
 
 ---
 
@@ -142,7 +142,7 @@ Import the existing resources to the Terraform state, replacing the
 uppercase values with the aforementioned values:
 
 ```sh
-./import.sh -m forseti -o ORG_ID -p PROJECT_ID -r RESOURCE_NAME_SUFFIX
+./import.sh -m MODULE_LOCAL_NAME -o ORG_ID -p PROJECT_ID -s RESOURCE_NAME_SUFFIX -z GCE_ZONE [-n NETWORK_PROJECT_ID]
 ```
 
 Observe the expected Terraform changes

--- a/_includes/docs/latest/get-help-question.md
+++ b/_includes/docs/latest/get-help-question.md
@@ -2,7 +2,7 @@
 
 You can get community support in several ways:
 
-* Join our [Slack Channel](https://www.google.com/url?q=https://forsetisecurity.slack.com/join/shared_invite/enQtNDIyMzg4Nzg1NjcxLTJhYjI1YzY0MDg4YjRhMDhhZTMwZTg0MWExZjU1MTNiNWFmMmFlMWQ0MmI3OTE1MzczZTMwNTEzNDZiNDY3NTY&sa=D&source=hangouts&ust=1535149516876000&usg=AFQjCNGMeqXkmXooWT77Zvz0mZY5NnBMvQ)
+* Join our [Slack Channel](https://forsetisecurity.slack.com/join/shared_invite/enQtNDIyMzg4Nzg1NjcxLTM1NTUzZmM2ODVmNzE5MWEwYzAwNjUxMjVkZjhmYWZiOGZjMjY3ZjllNDlkYjk1OGU4MTVhZGM4NzgyZjZhNTE)
   and engage in discussions with other users and Forseti community.
 * Join our office hours via [Hangouts](https://meet.google.com/ugq-dchi-rmw)
   that we hold every Tuesday from 9 AM - 9:30 AM PST.


### PR DESCRIPTION
Update the Slack invitation URL which has gone inactive and no longer works.

I also updated the syntax displayed for the Python -> Terraform import script which changed right before we released.

Typically this should be done in separate PRs, but to save time and get these static/non-code changes out faster, I am combining into one.

Addresses #3235.