### PR TITLE
Fix the Group Settings Type

### DIFF
--- a/google/cloud/forseti/common/gcp_type/groups_settings.py
+++ b/google/cloud/forseti/common/gcp_type/groups_settings.py
@@ -44,7 +44,7 @@ class GroupsSettings(resource.Resource):
             whoCanViewMembership (str): Setting for who can view membership.
             whoCanViewGroup (str): Setting for who can view group.
             whoCanInvite (str): Setting for who can invite to group.
-            allowExternalMembers (str): Setting for are external members
+            allowExternalMembers (bool): Setting for are external members
             allowed.
             whoCanLeaveGroup (str): Setting for who can leave group.
         """
@@ -57,7 +57,7 @@ class GroupsSettings(resource.Resource):
         self.whoCanViewMembership = whoCanViewMembership
         self.whoCanViewGroup = whoCanViewGroup
         self.whoCanInvite = whoCanInvite
-        self.allowExternalMembers = bool(allowExternalMembers)
+        self.allowExternalMembers = allowExternalMembers
         self.whoCanLeaveGroup = whoCanLeaveGroup
 
     @classmethod
@@ -79,5 +79,6 @@ class GroupsSettings(resource.Resource):
             whoCanViewMembership=settings.get('whoCanViewMembership'),
             whoCanViewGroup=settings.get('whoCanViewGroup'),
             whoCanInvite=settings.get('whoCanInvite'),
-            allowExternalMembers=settings.get('allowExternalMembers'),
+            allowExternalMembers=str(
+                settings.get('allowExternalMembers', '')).lower() == 'true',
             whoCanLeaveGroup=settings.get('whoCanLeaveGroup'))

--- a/google/cloud/forseti/services/dao.py
+++ b/google/cloud/forseti/services/dao.py
@@ -750,7 +750,7 @@ def define_model(model_name, dbengine, model_seed):
                 session (object): Database session.
                 only_iam_groups (bool): boolean indicating whether we want to
                 only fetch groups settings for which there is at least 1 iam
-                policy
+                policy.
 
             Yields:
                 Resource: resource that match the query

--- a/rules/groups_settings_rules.yaml
+++ b/rules/groups_settings_rules.yaml
@@ -40,11 +40,10 @@ rules:
     groups_emails:
       - '*'
     settings:
-      allowExternalMembers: True
+      allowExternalMembers: False
       whoCanJoin: "INVITED_CAN_JOIN"
       whoCanInvite: "ALL_MANAGERS_CAN_INVITE"
       whoCanAdd: "ALL_MANAGERS_CAN_ADD"
-      allowExternalMembers: False
       whoCanLeaveGroup: "ALL_MANAGERS_CAN_LEAVE"
   # - name: Recommended for groups only used for IAM and not for email
   #   mode: whitelist

--- a/tests/common/gcp_type/folder_test.py
+++ b/tests/common/gcp_type/folder_test.py
@@ -86,6 +86,5 @@ class FolderTest(ForsetiTestCase):
                          my_folder.lifecycle_state)
 
 
-
 if __name__ == '__main__':
     unittest.main()

--- a/tests/common/gcp_type/group_settings_test.py
+++ b/tests/common/gcp_type/group_settings_test.py
@@ -1,0 +1,57 @@
+# Copyright 2017 The Forseti Security Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests the Folder resource"""
+
+import unittest
+
+from tests.unittest_utils import ForsetiTestCase
+from google.cloud.forseti.common.gcp_type import groups_settings
+
+EMAIL = 'testgroup@test.com'
+
+_GROUPS_SETTINGS_JSON = """
+{
+    "allowExternalMembers": "false",
+    "email": "testgroup@test.org",
+    "name": "TestGroup",
+    "whoCanAdd": "ALL_MANAGERS_CAN_ADD",
+    "whoCanInvite": "ALL_MANAGERS_CAN_INVITE",
+    "whoCanJoin": "INVITED_CAN_JOIN",
+    "whoCanLeaveGroup": "ALL_MEMBERS_CAN_LEAVE",
+    "whoCanViewMembership": "ALL_IN_DOMAIN_CAN_VIEW",
+    "whoCanViewGroup": "ALL_IN_DOMAIN_CAN_VIEW"
+}"""
+
+
+class GroupSettingsTest(ForsetiTestCase):
+    """Test Group Settings resource."""
+
+    def test_create_groups_settings_from_json(self):
+        """Tests creation of a group settings resource from a JSON string."""
+        my_groups_settings = groups_settings.GroupsSettings.from_json(
+            email=EMAIL,
+            settings=_GROUPS_SETTINGS_JSON)
+        self.assertEqual(EMAIL, my_groups_settings.name)
+        self.assertFalse(my_groups_settings.allowExternalMembers)
+        self.assertEqual('ALL_MANAGERS_CAN_ADD', my_groups_settings.whoCanAdd)
+        self.assertEqual('ALL_MANAGERS_CAN_INVITE', my_groups_settings.whoCanInvite)
+        self.assertEqual('INVITED_CAN_JOIN', my_groups_settings.whoCanJoin)
+        self.assertEqual('ALL_MEMBERS_CAN_LEAVE', my_groups_settings.whoCanLeaveGroup)
+        self.assertEqual('ALL_IN_DOMAIN_CAN_VIEW', my_groups_settings.whoCanViewGroup)
+        self.assertEqual('ALL_IN_DOMAIN_CAN_VIEW', my_groups_settings.whoCanViewMembership)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/scanner/scanners/data/groups_settings_scanner_test_rules.yaml
+++ b/tests/scanner/scanners/data/groups_settings_scanner_test_rules.yaml
@@ -23,3 +23,14 @@ rules:
     settings:
       whoCanLeaveGroup: "ALL_MEMBERS_CAN_LEAVE"
       whoCanInvite: "ALL_MANAGERS_CAN_INVITE"
+  - name: All groups with iam policies should have all of these settings
+    mode: whitelist
+    only_iam_groups: True
+    groups_emails:
+      - 'settings6@testing.com'
+    settings:
+      allowExternalMembers: False
+      whoCanAdd: "ALL_MANAGERS_CAN_ADD"
+      whoCanInvite: "ALL_MANAGERS_CAN_INVITE"
+      whoCanJoin: "INVITED_CAN_JOIN"
+      whoCanLeaveGroup: "ALL_MEMBERS_CAN_LEAVE"

--- a/tests/scanner/scanners/groups_settings_scanner_test.py
+++ b/tests/scanner/scanners/groups_settings_scanner_test.py
@@ -18,17 +18,13 @@ from builtins import object
 import unittest
 import unittest.mock as mock
 import json
-from datetime import datetime
 
 from tests import unittest_utils
 from tests.services.util.db import create_test_engine
 from tests.scanner.test_data.fake_groups_settings_scanner_data import (
     SETTINGS_1, SETTINGS_3, SETTINGS_5, SETTINGS)
-from google.cloud.forseti.common.gcp_type import resource as resource_mod
 from google.cloud.forseti.scanner.scanners import groups_settings_scanner
-from google.cloud.forseti.common.util.string_formats import TIMESTAMP_MICROS
 from google.cloud.forseti.services.dao import ModelManager
-
 
 """
 Rule 1 mainly tests that blacklist picks up violations when
@@ -40,6 +36,7 @@ Rule 2 mainly tests that scanner works with specific resource ids
 Rule 3 mainly tests that whitelist breaks when and only
 when at least one specified property is violated
 """
+
 
 class FakeServiceConfig(object):
 
@@ -67,7 +64,7 @@ class GroupsSettingsScannerTest(unittest_utils.ForsetiTestCase):
 
         # Add organization to model.
         with scoped_session as session:
-           for settings_row in SETTINGS:
+            for settings_row in SETTINGS:
                 add_settings_to_test_db(settings_row)
 
     def setUp(self):
@@ -82,16 +79,16 @@ class GroupsSettingsScannerTest(unittest_utils.ForsetiTestCase):
     def test_run_scanner(self, mock_output_results):
         self.scanner.run()
         all_groups_settings, iam_groups_settings = self.scanner._retrieve()
-        violations = self.scanner._find_violations(all_groups_settings, 
+        violations = self.scanner._find_violations(all_groups_settings,
                                                    iam_groups_settings)
         self.assertEqual(1, mock_output_results.call_count)
         self.assertEqual(3, len(violations))
         self.assertEqual(json.loads(SETTINGS_1['settings'])['email'],
-                          violations[0].group_email)
+                         violations[0].group_email)
         self.assertEqual(json.loads(SETTINGS_3['settings'])['email'],
-                          violations[1].group_email)
+                         violations[1].group_email)
         self.assertEqual(json.loads(SETTINGS_5['settings'])['email'],
-                          violations[2].group_email)
+                         violations[2].group_email)
 
 
 if __name__ == '__main__':

--- a/tests/scanner/test_data/fake_groups_settings_scanner_data.py
+++ b/tests/scanner/test_data/fake_groups_settings_scanner_data.py
@@ -16,54 +16,63 @@
 import json
 
 SETTINGS_1 = {
-	'group_name': 'group/settings1@testing.com',
-	'settings': json.dumps({
-		 "allowExternalMembers": "true","whoCanViewMembership": "ALL_IN_DOMAIN_CAN_VIEW", 
-		 "email": "settings1@testing.com","whoCanLeaveGroup": "ALL_MEMBERS_CAN_LEAVE", 
-		 "whoCanAdd": "ALL_MANAGERS_CAN_ADD", "whoCanJoin": "INVITED_CAN_JOIN",  
-		 "whoCanInvite": "ALL_MANAGERS_CAN_INVITE", "type": "SETTINGS", 
-		"whoCanViewGroup": "ALL_IN_DOMAIN_CAN_VIEW", })
+    'group_name': 'group/settings1@testing.com',
+    'settings': json.dumps({
+        "allowExternalMembers": "true", "whoCanViewMembership": "ALL_IN_DOMAIN_CAN_VIEW",
+        "email": "settings1@testing.com", "whoCanLeaveGroup": "ALL_MEMBERS_CAN_LEAVE",
+        "whoCanAdd": "ALL_MANAGERS_CAN_ADD", "whoCanJoin": "INVITED_CAN_JOIN",
+        "whoCanInvite": "ALL_MANAGERS_CAN_INVITE", "type": "SETTINGS",
+        "whoCanViewGroup": "ALL_IN_DOMAIN_CAN_VIEW", })
 }
 
-
 SETTINGS_2 = {
-	'group_name': 'group/settings2@testing.com',
-	'settings': json.dumps({
-		 "allowExternalMembers": "true","whoCanViewMembership": "ALL_IN_DOMAIN_CAN_VIEW", 
-		 "email": "settings2@testing.com","whoCanLeaveGroup": "ALL_MEMBERS_CAN_LEAVE", 
-		 "whoCanAdd": "ALL_MANAGERS_CAN_ADD", "whoCanJoin": "ALL_IN_DOMAIN_CAN_JOIN",  
-		 "whoCanInvite": "ALL_MANAGERS_CAN_INVITE", "type": "SETTINGS", 
-		"whoCanViewGroup": "ALL_IN_DOMAIN_CAN_VIEW", })
+    'group_name': 'group/settings2@testing.com',
+    'settings': json.dumps({
+        "allowExternalMembers": "true", "whoCanViewMembership": "ALL_IN_DOMAIN_CAN_VIEW",
+        "email": "settings2@testing.com", "whoCanLeaveGroup": "ALL_MEMBERS_CAN_LEAVE",
+        "whoCanAdd": "ALL_MANAGERS_CAN_ADD", "whoCanJoin": "ALL_IN_DOMAIN_CAN_JOIN",
+        "whoCanInvite": "ALL_MANAGERS_CAN_INVITE", "type": "SETTINGS",
+        "whoCanViewGroup": "ALL_IN_DOMAIN_CAN_VIEW", })
 }
 
 SETTINGS_3 = {
-	'group_name': 'group/non_wildcard@test.com',
-	'settings': json.dumps({
-		 "allowExternalMembers": "true","whoCanViewMembership": "ALL_IN_DOMAIN_CAN_VIEW", 
-		 "email": "non_wildcard@test.com","whoCanLeaveGroup": "ALL_MEMBERS_CAN_LEAVE", 
-		 "whoCanAdd": "ALL_MANAGERS_CAN_ADD", "whoCanJoin": "ALL_IN_DOMAIN_CAN_JOIN",  
-		 "whoCanInvite": "ALL_MANAGERS_CAN_INVITE", "type": "SETTINGS", 
-		"whoCanViewGroup": "ALL_IN_DOMAIN_CAN_VIEW", })
+    'group_name': 'group/non_wildcard@test.com',
+    'settings': json.dumps({
+        "allowExternalMembers": "true", "whoCanViewMembership": "ALL_IN_DOMAIN_CAN_VIEW",
+        "email": "non_wildcard@test.com", "whoCanLeaveGroup": "ALL_MEMBERS_CAN_LEAVE",
+        "whoCanAdd": "ALL_MANAGERS_CAN_ADD", "whoCanJoin": "ALL_IN_DOMAIN_CAN_JOIN",
+        "whoCanInvite": "ALL_MANAGERS_CAN_INVITE", "type": "SETTINGS",
+        "whoCanViewGroup": "ALL_IN_DOMAIN_CAN_VIEW", })
 }
 
 SETTINGS_4 = {
-	'group_name': 'group/non_wildcard2@test.com',
-	'settings': json.dumps({
-		 "allowExternalMembers": "true","whoCanViewMembership": "ALL_IN_DOMAIN_CAN_VIEW", 
-		 "email": "non_wildcard2@test.com","whoCanLeaveGroup": "ALL_MEMBERS_CAN_LEAVE", 
-		 "whoCanAdd": "ALL_MANAGERS_CAN_ADD", "whoCanJoin": "ALL_IN_DOMAIN_CAN_JOIN",  
-		 "whoCanInvite": "ALL_MANAGERS_CAN_INVITE", "type": "SETTINGS", 
-		"whoCanViewGroup": "ANYONE_CAN_VIEW", })
+    'group_name': 'group/non_wildcard2@test.com',
+    'settings': json.dumps({
+        "allowExternalMembers": "true", "whoCanViewMembership": "ALL_IN_DOMAIN_CAN_VIEW",
+        "email": "non_wildcard2@test.com", "whoCanLeaveGroup": "ALL_MEMBERS_CAN_LEAVE",
+        "whoCanAdd": "ALL_MANAGERS_CAN_ADD", "whoCanJoin": "ALL_IN_DOMAIN_CAN_JOIN",
+        "whoCanInvite": "ALL_MANAGERS_CAN_INVITE", "type": "SETTINGS",
+        "whoCanViewGroup": "ANYONE_CAN_VIEW", })
 }
 
 SETTINGS_5 = {
-	'group_name': 'group/settings5@testing.com',
-	'settings': json.dumps({
-		 "allowExternalMembers": "true","whoCanViewMembership": "ALL_IN_DOMAIN_CAN_VIEW", 
-		 "email": "settings5@testing.com","whoCanLeaveGroup": "NONE_CAN_LEAVE", 
-		 "whoCanAdd": "ALL_MANAGERS_CAN_ADD", "whoCanJoin": "ALL_IN_DOMAIN_CAN_JOIN",  
-		 "whoCanInvite": "ALL_MANAGERS_CAN_INVITE", "type": "SETTINGS", 
-		"whoCanViewGroup": "ANYONE_CAN_VIEW", })
+    'group_name': 'group/settings5@testing.com',
+    'settings': json.dumps({
+        "allowExternalMembers": "true", "whoCanViewMembership": "ALL_IN_DOMAIN_CAN_VIEW",
+        "email": "settings5@testing.com", "whoCanLeaveGroup": "NONE_CAN_LEAVE",
+        "whoCanAdd": "ALL_MANAGERS_CAN_ADD", "whoCanJoin": "ALL_IN_DOMAIN_CAN_JOIN",
+        "whoCanInvite": "ALL_MANAGERS_CAN_INVITE", "type": "SETTINGS",
+        "whoCanViewGroup": "ANYONE_CAN_VIEW", })
 }
 
-SETTINGS = [SETTINGS_1, SETTINGS_2, SETTINGS_3, SETTINGS_4, SETTINGS_5]
+SETTINGS_6 = {
+    'group_name': 'group/settings6@testing.com',
+    'settings': json.dumps({
+        "allowExternalMembers": "false", "whoCanViewMembership": "ALL_IN_DOMAIN_CAN_VIEW",
+        "email": "settings6@testing.com", "whoCanLeaveGroup": "ALL_MEMBERS_CAN_LEAVE",
+        "whoCanAdd": "ALL_MANAGERS_CAN_ADD", "whoCanJoin": "INVITED_CAN_JOIN",
+        "whoCanInvite": "ALL_MANAGERS_CAN_INVITE", "type": "SETTINGS",
+        "whoCanViewGroup": "ANYONE_CAN_VIEW", })
+}
+
+SETTINGS = [SETTINGS_1, SETTINGS_2, SETTINGS_3, SETTINGS_4, SETTINGS_5, SETTINGS_6]


### PR DESCRIPTION
The GSuite API is returning the `allowExternalMembers` as a string: either `false` or `true`. Since this is not returned as a json boolean, the json.loads() method is not converting this to a Python boolean value. This means that all non-empty strings will be converted to True by the bool() method. This fix correctly converts these strings to a Python bool.

Addresses #2880 