### PR TITLE
Format Location Violation data as a dictionary

### DIFF
--- a/google/cloud/forseti/notifier/notifiers/slack_webhook.py
+++ b/google/cloud/forseti/notifier/notifiers/slack_webhook.py
@@ -38,6 +38,12 @@ class SlackWebhook(base_notification.BaseNotification):
             output: a string formatted violation
         """
         output = ''
+
+        if not isinstance(data, dict):
+            LOGGER.debug('Violation data is not a dictionary type. '
+                         f'Violation data: {data}')
+            return '\t' * (indent + 1) + '`' + str(data) + '`\n'
+
         for key, value in sorted(data.items()):
             output += '\t' * indent + '*' + str(key) + '*:'
             if isinstance(value, dict):

--- a/google/cloud/forseti/scanner/audit/location_rules_engine.py
+++ b/google/cloud/forseti/scanner/audit/location_rules_engine.py
@@ -299,6 +299,11 @@ class Rule(object):
         )
 
         if has_violation:
+            violation_data = {
+                'full_name': res.full_name,
+                'resource_type': res.type,
+                'locations': res.locations
+            }
             yield RuleViolation(
                 resource_id=res.id,
                 resource_name=res.display_name,
@@ -307,7 +312,7 @@ class Rule(object):
                 rule_index=self.index,
                 rule_name=self.name,
                 violation_type='LOCATION_VIOLATION',
-                violation_data=str(res.locations),
+                violation_data=violation_data,
                 resource_data=res.data,
             )
             return

--- a/tests/notifier/notifiers/slack_webhook_test.py
+++ b/tests/notifier/notifiers/slack_webhook_test.py
@@ -52,6 +52,19 @@ class SlackWebhooknotifierTest(ForsetiTestCase):
 
             self.assertEqual(expected_output.strip(), actual_output.strip())
 
+    def test_dump_slack_output_for_string_returns_string(self):
+        violation_data = 'Test violation data string'
+        with mock.patch.object(
+                slack_webhook.SlackWebhook,
+                '__init__',
+                lambda x: None):
+            slack_notifier = slack_webhook.SlackWebhook()
+            actual_output = slack_notifier._dump_slack_output(violation_data)
+
+            expected_output = '\t' + '`' + str(violation_data) + '`\n'
+
+            self.assertEqual(expected_output.strip(), actual_output.strip())
+
     def test_no_url_no_run_notifier(self):
         """Test that no url for Slack notifier will skip running."""
         with mock.patch.object(slack_webhook.SlackWebhook, '__init__', lambda x: None):

--- a/tests/scanner/audit/location_rules_engine_test.py
+++ b/tests/scanner/audit/location_rules_engine_test.py
@@ -14,20 +14,12 @@
 
 """Tests the LocationRulesEngine."""
 
-import copy
-import itertools
-import json
 import unittest.mock as mock
 import tempfile
 import unittest
-import yaml
 
 from tests.unittest_utils import ForsetiTestCase
-from google.cloud.forseti.common.util import file_loader
-from google.cloud.forseti.scanner.audit.errors import InvalidRulesSchemaError
 from google.cloud.forseti.scanner.audit import location_rules_engine
-from google.cloud.forseti.scanner.audit import rules as scanner_rules
-from tests.unittest_utils import get_datafile_path
 from tests.scanner.test_data import fake_location_scanner_data as data
 
 
@@ -43,7 +35,6 @@ rules:
           resource_ids: {ids}
     locations: {locations}
 """
-
 
 
 def get_rules_engine_with_rule(rule):
@@ -236,6 +227,7 @@ rules:
         rules_engine = get_rules_engine_with_rule(rule)
         got_violations = list(rules_engine.find_violations(data.BUCKET))
         self.assertEqual(got_violations, data.build_violations(data.BUCKET))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/scanner/test_data/fake_location_scanner_data.py
+++ b/tests/scanner/test_data/fake_location_scanner_data.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Location data to be used in the unit tests."""
 
-from builtins import str
 from google.cloud.forseti.common.gcp_type import organization
 from google.cloud.forseti.common.gcp_type import project
 from google.cloud.forseti.common.gcp_type import resource_util
@@ -92,6 +91,7 @@ _GCE_INSTANCE_JSON = """{
 GCE_INSTANCE = resource_util.create_resource_from_json(
     'instance', PROJECT, _GCE_INSTANCE_JSON)
 
+
 def build_violations(res):
     """Build an expected violation.
 
@@ -101,6 +101,11 @@ def build_violations(res):
     Returns:
         RuleViolation: The violation.
     """
+    violation_data = {
+        'full_name': res.full_name,
+        'resource_type': res.type,
+        'locations': res.locations
+    }
     return [location_rules_engine.RuleViolation(
         resource_id=res.id,
         resource_name=res.display_name,
@@ -109,6 +114,6 @@ def build_violations(res):
         rule_index=0,
         rule_name='Location test rule',
         violation_type='LOCATION_VIOLATION',
-        violation_data=str(res.locations),
+        violation_data=violation_data,
         resource_data=res.data,
     )]


### PR DESCRIPTION
Updated the location rules engine to format violation data as a dictionary because the Slack notifier expects this. Updated the Slack notifier to log the issue and not throw an exception, otherwise this prevents other violations from being sent to Slack.

Addresses #3231 