### PR TITLE
Updated scanner_iter method to use query.slice() instead of yield_per and increased the cv audit size to 100mb per.

### DIFF
--- a/google/cloud/forseti/scanner/scanners/config_validator_util/validator_client.py
+++ b/google/cloud/forseti/scanner/scanners/config_validator_util/validator_client.py
@@ -48,8 +48,8 @@ class ValidatorClient(object):
         # Default grpc message size limit is 4MB, set the
         # max page size to 3.5 MB.
         self.max_page_size = 1024 ** 2 * 3.5
-        # Audit once every 50 MB of data sent to Config Validator.
-        self.max_audit_size = 1024 ** 2 * 50
+        # Audit once every 100 MB of data sent to Config Validator.
+        self.max_audit_size = 1024 ** 2 * 100
         self.channel = grpc.insecure_channel(endpoint, options=[
             ('grpc.max_receive_message_length', self.max_length)])
         self.stub = validator_pb2_grpc.ValidatorStub(self.channel)

--- a/google/cloud/forseti/services/dao.py
+++ b/google/cloud/forseti/services/dao.py
@@ -736,7 +736,8 @@ def define_model(model_name, dbengine, model_seed):
                 .enable_eagerloads(True))
 
             if parent_type_name:
-                query = query.filter(Resource.parent_type_name == parent_type_name)
+                query = query.filter(
+                    Resource.parent_type_name == parent_type_name)
 
             block_size = PER_YIELD
             block_number = 0

--- a/google/cloud/forseti/services/dao.py
+++ b/google/cloud/forseti/services/dao.py
@@ -62,7 +62,7 @@ from google.cloud.forseti.common.util import logger
 LOGGER = logger.get_logger(__name__)
 
 POOL_RECYCLE_SECONDS = 300
-PER_YIELD = 1024
+PER_YIELD = 4096
 
 
 def generate_model_handle():


### PR DESCRIPTION
Resolves #3224 