### PR TITLE
Update Firewall Rule Validation

### DIFF
--- a/google/cloud/forseti/common/gcp_type/firewall_rule.py
+++ b/google/cloud/forseti/common/gcp_type/firewall_rule.py
@@ -686,10 +686,6 @@ class FirewallAction(object):
                 raise InvalidFirewallActionError(
                     'Action must have field IPProtocol')
             if 'ports' in rule:
-                if rule['IPProtocol'] not in ['tcp', 'udp']:
-                    raise InvalidFirewallActionError(
-                        'Only "tcp" and "udp" can have ports specified: %s' %
-                        rule)
                 for port in rule['ports']:
                     if '-' in port:
                         validate_port_range(port)

--- a/tests/common/gcp_type/firewall_rule_test.py
+++ b/tests/common/gcp_type/firewall_rule_test.py
@@ -1166,15 +1166,6 @@ class FirewallActionTest(ForsetiTestCase):
             {
                 'firewall_rules':
                 [
-                    {'IPProtocol': 'ucp', 'ports': ['21-23']},
-                ],
-            },
-            'Only "tcp" and "udp" can have ports specified',
-        ),
-        (
-            {
-                'firewall_rules':
-                [
                     {'IPProtocol': 'udp', 'ports': ['100-50']},
                 ],
             },


### PR DESCRIPTION
Removing the validation that is performed on firewall rules when a port is specified for protocols other than TCP/UDP. Firewall rules can be added that specify a port for protocols other than TCP/UDP, and these exceptions are preventing the scanner from completing.

Resolves issues seen by the FirewallPolicyScanner and IapScanner as seen on issue #3152 .