### PR TITLE
Ensure we don't use stale models that will lead to stale violations.

### DIFF
--- a/install/gcp/scripts/run_forseti.sh
+++ b/install/gcp/scripts/run_forseti.sh
@@ -44,6 +44,9 @@ forseti server configuration reload
 # Set the output format to json
 forseti config format json
 
+# Ensure we are not using stale model, and produce stale violations.
+forseti config delete model
+
 # Purge inventory.
 # Use retention_days from configuration yaml file.
 forseti inventory purge
@@ -57,9 +60,10 @@ echo "Finished running Forseti inventory."
 GET_MODEL_STATUS="forseti model get ${MODEL_NAME} | python -c \"import sys, json; print json.load(sys.stdin)['status']\""
 MODEL_STATUS=`eval $GET_MODEL_STATUS`
 
-if [ "$MODEL_STATUS" == "BROKEN" ]
+if ([ "$MODEL_STATUS" != "SUCCESS" ] && [ "$MODEL_STATUS" != "PARTIAL_SUCCESS" ])
     then
-        echo "Model is broken, please contact discuss@forsetisecurity.org for support."
+        echo "Newly created Model is not in SUCCESS or PARTIAL_SUCCESS state."
+        echo "Please contact discuss@forsetisecurity.org for support."
         exit
 fi
 


### PR DESCRIPTION
Fixes #1971  This will handle when get model returns `{ }` case, as well.