### PR TITLE
Minor website updates for v2.22.0 (#3265)

### DIFF
--- a/_docs/_latest/setup/install-with-python-installer.md
+++ b/_docs/_latest/setup/install-with-python-installer.md
@@ -12,12 +12,11 @@ This guide explains how to use the python-based Forseti installation tool.
 ## Before you begin
 
 <span style="color:red">
-This python-based installer will be deprecated on September 30, 2019.
+This python-based installer will be deprecated on with Forseti Release v2.23.0.
+</span>
 
 It is highly recommended that you try the easier to use terraform-based
-installer, which will become the only installer available after
-September 30, 2019.
-</span>
+installer, which will become the only installer available with Forseti Release v2.23.0.
 
 ### Activate Google Cloud Shell
 

--- a/_docs/_latest/setup/upgrade.md
+++ b/_docs/_latest/setup/upgrade.md
@@ -1116,16 +1116,14 @@ Example command: `gcloud compute instances reset forseti-server-vm-70ce82f --zon
 1. Repeat step `3-9` for Forseti client.
 1. Configuration file `forseti_conf_server.yaml` updates:  
    **Inventory**
-   - Add Bigtable Cluster, Instance and Table as Cloud Asset Inventory assets.
+   - Add Compute Security Policy to the Cloud Asset Inventory asset types.
       ```
         inventory:
             ...
             cai:
                  ...
                  #asset_types:
-                    #    - bigtableadmin.googleapis.com/Cluster
-                    #    - bigtableadmin.googleapis.com/Instance
-                    #    - bigtableadmin.googleapis.com/Table
+                    #    - compute.googleapis.com/SecurityPolicy
             ...
       ```
 

--- a/_docs/v2.22/develop/dev/setup.md
+++ b/_docs/v2.22/develop/dev/setup.md
@@ -118,7 +118,7 @@ server and the command-line interface (CLI) client:
   ```bash
   forseti_server \
   --endpoint "localhost:50051" \
-  --forseti_db "mysql://root@127.0.0.1:3306/forseti_security" \
+  --forseti_db "mysql+pymysql://root@127.0.0.1:3306/forseti_security" \
   --services scanner model inventory explain notifier \
   --config_file_path "PATH_TO_YOUR_CONFIG.yaml" \
   --log_level=info \

--- a/_docs/v2.22/develop/dev/testing.md
+++ b/_docs/v2.22/develop/dev/testing.md
@@ -78,7 +78,7 @@ want to run the tests in Docker with your local changes, you need to do the foll
    docker ps
  
    # Copy the files from the local disk to the image
-   docker cp ./ <forseti/build_container_id>:/forseti-security/
+   docker cp ./ <forseti/build_container_id>:/home/forseti/forseti-security/
 
    # If you want to turn down the Docker container:
    docker kill <forseti/build_container_id>

--- a/_docs/v2.22/setup/install-with-python-installer.md
+++ b/_docs/v2.22/setup/install-with-python-installer.md
@@ -12,12 +12,11 @@ This guide explains how to use the python-based Forseti installation tool.
 ## Before you begin
 
 <span style="color:red">
-This python-based installer will be deprecated on September 30, 2019.
+This python-based installer will be deprecated on with Forseti Release v2.23.0.
+</span>
 
 It is highly recommended that you try the easier to use terraform-based
-installer, which will become the only installer available after
-September 30, 2019.
-</span>
+installer, which will become the only installer available with Forseti Release v2.23.0.
 
 ### Activate Google Cloud Shell
 

--- a/_docs/v2.22/setup/upgrade.md
+++ b/_docs/v2.22/setup/upgrade.md
@@ -1116,16 +1116,14 @@ Example command: `gcloud compute instances reset forseti-server-vm-70ce82f --zon
 1. Repeat step `3-9` for Forseti client.
 1. Configuration file `forseti_conf_server.yaml` updates:  
    **Inventory**
-   - Add Bigtable Cluster, Instance and Table as Cloud Asset Inventory assets.
+   - Add Compute Security Policy to the Cloud Asset Inventory asset types.
       ```
         inventory:
             ...
             cai:
                  ...
                  #asset_types:
-                    #    - bigtableadmin.googleapis.com/Cluster
-                    #    - bigtableadmin.googleapis.com/Instance
-                    #    - bigtableadmin.googleapis.com/Table
+                    #    - compute.googleapis.com/SecurityPolicy
             ...
       ```
 


### PR DESCRIPTION
* Updated the CAI resources section of the Python installer upgrade steps. Added some minor changes recently added to the latest docs to the 2.22.0 docs.

* Updated data for python installer deprecation.