### PR TITLE
Created G Suite group for integration testing

### DIFF
--- a/integration_tests/fixtures/forseti/main.tf
+++ b/integration_tests/fixtures/forseti/main.tf
@@ -135,3 +135,15 @@ resource "google_kms_crypto_key" "test-crypto-key" {
   rotation_period = "100000s"
 }
 
+provider "gsuite" {
+  version     = "~> 0.1"
+  credentials = "/workspace/release-silver.json"
+  impersonated_user_email = "admin@silver.forsetisecurity.dev"
+}
+
+resource "gsuite_group" "devteam" {
+  email       = "automated-group-creation@silver.forsetisecurity.dev"
+  name        = "automated-group-creation@silver.forsetisecurity.dev"
+  description = "G Suite Group Automated Creation Testing"
+}
+


### PR DESCRIPTION
G Suite group has been created using the CFT framework for integration testing to prove that G Suite resources can also be created using the chosen framework.