### PR TITLE
Add Service Usage API and other missing APIs to required-apis.md section

### DIFF
--- a/_includes/docs/latest/required-apis.md
+++ b/_includes/docs/latest/required-apis.md
@@ -5,10 +5,18 @@
 |Admin SDK|`admin.googleapis.com`|
 |App Engine Admin|`appengine.googleapis.com`|
 |BigQuery|`bigquery-json.googleapis.com`|
+|Cloud Asset|`cloudasset.googleapis.com`|
 |Cloud Billing|`cloudbilling.googleapis.com`|
 |Cloud IAM|`iam.googleapis.com`|
-|Resource Manager|`cloudresourcemanager.googleapis.com`|
 |Cloud SQL Administration|`sqladmin.googleapis.com`|
 |Cloud SQL|`sql-component.googleapis.com`|
+|Cloud Storage|`storage-api.googleapis.com`|
 |Compute Engine|`compute.googleapis.com`|
 |Deployment Manager|`deploymentmanager.googleapis.com`|
+|Groups Settings|`groupssettings.googleapis.com`|
+|Kubernetes Engine|`container.googleapis.com`|
+|Resource Manager|`cloudresourcemanager.googleapis.com`|
+|Stackdriver Logging|`logging.googleapis.com`|
+|Stackdriver Trace|`cloudtrace.googleapis.com`|
+|Service Management|`servicemanagement.googleapis.com`|
+|Service Usage|`serviceusage.googleapis.com`|


### PR DESCRIPTION
Add Service Usage API and other missing APIs to `required-apis.md` section. This section is found in:

https://forsetisecurity.org/docs/latest/develop/dev/setup.html#enabling-apis
https://forsetisecurity.org/docs/latest/setup/manual.html#enable-apis