### PR TITLE
Remove Validation on Firewall Names

### DIFF
--- a/google/cloud/forseti/common/gcp_type/firewall_rule.py
+++ b/google/cloud/forseti/common/gcp_type/firewall_rule.py
@@ -691,11 +691,6 @@ class FirewallAction(object):
                         validate_port_range(port)
                     else:
                         validate_port(port)
-            invalid_keys = set(rule.keys()) - {'IPProtocol', 'ports'}
-            if invalid_keys:
-                raise InvalidFirewallActionError(
-                    'Action can only have "IPProtocol" and "ports": %s' %
-                    invalid_keys)
 
     @property
     def applies_to_all(self):

--- a/tests/common/gcp_type/firewall_rule_test.py
+++ b/tests/common/gcp_type/firewall_rule_test.py
@@ -1157,15 +1157,6 @@ class FirewallActionTest(ForsetiTestCase):
             {
                 'firewall_rules':
                 [
-                    {'IPProtocol': 'tcp', 'ports': ['21-23'], 'invalid': 'test'},
-                ],
-            },
-            'Action can only have "IPProtocol" and "ports"',
-        ),
-        (
-            {
-                'firewall_rules':
-                [
                     {'IPProtocol': 'udp', 'ports': ['100-50']},
                 ],
             },


### PR DESCRIPTION
Fixes #3325 where CAI provides both the old naming and the new naming at the same time.  So, removing this validation, as it doesn't seem very useful, and we can assume the firewall data that comes in has these fields.