### PR TITLE
Fix Requirements Link on GKE Setup page

### DIFF
--- a/_includes/docs/latest/setup-script-credentials.md
+++ b/_includes/docs/latest/setup-script-credentials.md
@@ -1,6 +1,6 @@
 Terraform uses an IAM Service Account to deploy and configure resources on behalf of the user.  The Service Account and required APIs can be setup automatically with a provided script on the 
 [Forseti Terraform Github repository](https://github.com/forseti-security/terraform-google-forseti/blob/master/helpers/setup.sh). 
-The Service Account and required APIs can also be configured manually by reviewing the [Requirements](#requirements) section.
+The Service Account and required APIs can also be configured manually by reviewing the [Requirements](https://forsetisecurity.org/docs/latest/setup/install.html#requirements) to deploy Forseti with Terraform.
 Alternatively, if you are an Org Admin, you can use your own credentials to install Forseti.
 
 ```bash


### PR DESCRIPTION
Fixed the requirements link on the GKE setup page. Jekyll/Liquid does not support using the link tag to link to an anchor on a page, so I am linking to the website directly instead of linking to the markdown file.

Fixes #3368