### PR TITLE
Store CAI export on GCS with Inventory Id in filename

### DIFF
--- a/tests/services/inventory/cloudasset_test.py
+++ b/tests/services/inventory/cloudasset_test.py
@@ -186,7 +186,8 @@ class InventoryCloudAssetTest(unittest_utils.ForsetiTestCase):
         self.mock_download.side_effect = _fake_download
 
         results = cloudasset.load_cloudasset_data(self.engine,
-                                                  self.inventory_config)
+                                                  self.inventory_config,
+                                                  self.inventory_index_id)
         self.assertTrue(results)
         self.validate_data_in_table()
 
@@ -231,7 +232,8 @@ class InventoryCloudAssetTest(unittest_utils.ForsetiTestCase):
         self.mock_download.side_effect = _fake_download
 
         results = cloudasset.load_cloudasset_data(self.engine,
-                                                  inventory_config)
+                                                  inventory_config,
+                                                  self.inventory_index_id)
         expected_results = 12  # Total of resources and IAM policies in dumps.
         self.assertEqual(expected_results, results)
 
@@ -268,11 +270,11 @@ class InventoryCloudAssetTest(unittest_utils.ForsetiTestCase):
             with open(fake_file, 'rb') as f:
                 output_file.write(f.read())
 
-
         self.mock_download.side_effect = _fake_download
 
         results = cloudasset.load_cloudasset_data(self.engine,
-                                                  self.inventory_config)
+                                                  self.inventory_config,
+                                                  self.inventory_index_id)
         # Expect both resources got imported.
         expected_results = 2
         self.assertEqual(results, expected_results)
@@ -305,7 +307,8 @@ class InventoryCloudAssetTest(unittest_utils.ForsetiTestCase):
             api_errors.ApiExecutionError('organizations/987654321', error_403)
         )
         results = cloudasset.load_cloudasset_data(self.engine,
-                                                  self.inventory_config)
+                                                  self.inventory_config,
+                                                  self.inventory_index_id)
         self.assertIsNone(results)
         self.assertFalse(self.mock_download.called)
         self.validate_no_data_in_table()
@@ -322,7 +325,9 @@ class InventoryCloudAssetTest(unittest_utils.ForsetiTestCase):
             ValueError('parent must start with folders/, projects/, or '
                        'organizations/'))
         with self.assertRaises(ValueError):
-            cloudasset.load_cloudasset_data(self.engine, inventory_config)
+            cloudasset.load_cloudasset_data(self.engine,
+                                            inventory_config,
+                                            self.inventory_index_id)
         self.assertFalse(self.mock_download.called)
         self.validate_no_data_in_table()
 
@@ -331,7 +336,8 @@ class InventoryCloudAssetTest(unittest_utils.ForsetiTestCase):
         self.mock_export_assets.side_effect = (
             api_errors.OperationTimeoutError('organizations/987654321', {}))
         results = cloudasset.load_cloudasset_data(self.engine,
-                                                  self.inventory_config)
+                                                  self.inventory_config,
+                                                  self.inventory_index_id)
         self.assertIsNone(results)
         self.assertFalse(self.mock_download.called)
         self.validate_no_data_in_table()
@@ -340,7 +346,8 @@ class InventoryCloudAssetTest(unittest_utils.ForsetiTestCase):
         """Validate load_cloud_asset handles an error result from CAI."""
         self.mock_export_assets.return_value = EXPORT_ASSETS_ERROR
         results = cloudasset.load_cloudasset_data(self.engine,
-                                                  self.inventory_config)
+                                                  self.inventory_config,
+                                                  self.inventory_index_id)
         self.assertIsNone(results)
         self.assertFalse(self.mock_download.called)
         self.validate_no_data_in_table()
@@ -357,9 +364,11 @@ class InventoryCloudAssetTest(unittest_utils.ForsetiTestCase):
         self.mock_download.side_effect = error_403
 
         results = cloudasset.load_cloudasset_data(self.engine,
-                                                  self.inventory_config)
+                                                  self.inventory_config,
+                                                  self.inventory_index_id)
         self.assertIsNone(results)
         self.validate_no_data_in_table()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/services/inventory/cloudasset_test.py
+++ b/tests/services/inventory/cloudasset_test.py
@@ -14,6 +14,7 @@
 """Unit Tests: Cloud Asset API integration for Forseti Server."""
 
 import os
+import time
 import unittest
 from googleapiclient import errors
 import httplib2
@@ -80,6 +81,7 @@ class InventoryCloudAssetTest(unittest_utils.ForsetiTestCase):
                                                 {'enabled': True,
                                                  'gcs_path': 'gs://test-bucket'}
                                                )
+        self.inventory_index_id = int(time.time()
         self.mock_auth = mock.patch.object(
             google.auth,
             'default',

--- a/tests/services/inventory/cloudasset_test.py
+++ b/tests/services/inventory/cloudasset_test.py
@@ -81,7 +81,7 @@ class InventoryCloudAssetTest(unittest_utils.ForsetiTestCase):
                                                 {'enabled': True,
                                                  'gcs_path': 'gs://test-bucket'}
                                                )
-        self.inventory_index_id = int(time.time()
+        self.inventory_index_id = int(time.time())
         self.mock_auth = mock.patch.object(
             google.auth,
             'default',

--- a/tests/services/inventory/crawling_test.py
+++ b/tests/services/inventory/crawling_test.py
@@ -15,6 +15,7 @@
 
 import copy
 import os
+import time
 import unittest
 import unittest.mock as mock
 from tests.services.inventory import gcp_api_mocks
@@ -22,8 +23,6 @@ from tests.services.util.mock import MockServerConfig
 from tests import unittest_utils
 from google.cloud.forseti.common.util import logger
 from google.cloud.forseti.services.base.config import InventoryConfig
-from google.cloud.forseti.services.inventory import cai_temporary_storage
-from google.cloud.forseti.services.inventory.storage import initialize
 from google.cloud.forseti.services.inventory.base.progress import Progresser
 from google.cloud.forseti.services.inventory.base.storage import Memory as MemoryStorage
 from google.cloud.forseti.services.inventory.crawler import run_crawler
@@ -92,6 +91,7 @@ class NullProgresser(Progresser):
     def __init__(self):
         super(NullProgresser, self).__init__()
         self.errors = 0
+        self.inventory_index_id = int(time.time())
         self.objects = 0
         self.warnings = 0
 


### PR DESCRIPTION
This change will use the current inventory id in the CAI export filename that is saved in GCS. Currently the timestamp of when the file created is used. This makes it difficult to automate testing around this feature.

Fixes #3345 