### PR TITLE
Feature/issues 3347 - Verify CAI export file is created in GCS

### DIFF
--- a/integration_tests/tests/forseti/controls/inventory-cai_gcs_export_file.rb
+++ b/integration_tests/tests/forseti/controls/inventory-cai_gcs_export_file.rb
@@ -22,9 +22,10 @@ random_string = SecureRandom.uuid.gsub!('-', '')
 
 control "inventory - cai gsc export file" do
   @inventory_id = /\"id\"\: \"([0-9]*)\"/.match(command("forseti inventory create --import_as #{random_string}").stdout)[1]
+  gs_file = "gs://forseti-cai-export-#{suffix}/organizations-#{org_id}-resource-#{@inventory_id}.dump"
 
-  describe google_storage_bucket_object(bucket: "forseti-cai-export-#{suffix}",  object: "organizations-#{org_id}-resource-#{@inventory_id}.dump") do
-    it { should exist }
+  describe command("gsutil ls #{gs_file} | grep #{gs_file}") do
+    its('stdout') { should match (gs_file)}
   end
 
   describe command("forseti model delete #{random_string}") do

--- a/integration_tests/tests/forseti/controls/inventory-cai_gcs_export_file.rb
+++ b/integration_tests/tests/forseti/controls/inventory-cai_gcs_export_file.rb
@@ -20,7 +20,7 @@ org_id = attribute('org_id')
 
 random_string = SecureRandom.uuid.gsub!('-', '')
 
-control "inventory - cai gsc export file" do
+control "inventory - cai gcs export file" do
   @inventory_id = /\"id\"\: \"([0-9]*)\"/.match(command("forseti inventory create --import_as #{random_string}").stdout)[1]
   gs_file = "gs://forseti-cai-export-#{suffix}/organizations-#{org_id}-resource-#{@inventory_id}.dump"
 

--- a/integration_tests/tests/forseti/controls/inventory-cai_gcs_export_file.rb
+++ b/integration_tests/tests/forseti/controls/inventory-cai_gcs_export_file.rb
@@ -31,4 +31,8 @@ control "inventory - cai gsc export file" do
   describe command("forseti model delete #{random_string}") do
     its('exit_status') { should eq 0 }
   end
+
+  describe command("forseti inventory delete #{@inventory_id}") do
+    its('exit_status') { should eq 0 }
+  end
 end

--- a/integration_tests/tests/forseti/controls/inventory-cai_gcs_export_file.rb
+++ b/integration_tests/tests/forseti/controls/inventory-cai_gcs_export_file.rb
@@ -1,0 +1,33 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'securerandom'
+require 'json'
+
+suffix = attribute('suffix')
+org_id = attribute('org_id')
+
+random_string = SecureRandom.uuid.gsub!('-', '')
+
+control "inventory - cai gsc export file" do
+  @inventory_id = /\"id\"\: \"([0-9]*)\"/.match(command("forseti inventory create --import_as #{random_string}").stdout)[1]
+
+  describe google_storage_bucket_object(bucket: "forseti-cai-export-#{suffix}",  object: "organizations-#{org_id}-resource-#{@inventory_id}.dump") do
+    it { should exist }
+  end
+
+  describe command("forseti model delete #{random_string}") do
+    its('exit_status') { should eq 0 }
+  end
+end


### PR DESCRIPTION
[root@a2da39b2370f workspace]# kitchen verify --test-base-path="integration_tests/tests"
-----> Starting Kitchen (v1.24.0)
-----> Verifying <forseti-local>...
$$$$$$ Running command `terraform workspace select kitchen-terraform-forseti-local` in directory /workspace/integration_tests/fixtures/forseti
$$$$$$ Running command `terraform output -json` in directory /workspace/integration_tests/fixtures/forseti
inventory-module: Verifying host 10.128.0.5
Skipping profile: 'inspec-gcp' on unsupported platform: 'ubuntu/18.04'.
...

Profile: forseti_integration_testing
Version: (not specified)
Target:  ssh://ubuntu@10.128.0.5:22

  ✔  inventory - cai gsc export file: Command: `gsutil ls gs://forseti-cai-export-a110fc59/organizations-92932930834-resource-1572993132795378.dump | grep gs://forseti-cai-export-a110fc59/organizations-92932930834-resource-1572993132795378.dump`
     ✔  Command: `gsutil ls gs://forseti-cai-export-a110fc59/organizations-92932930834-resource-1572993132795378.dump | grep gs://forseti-cai-export-a110fc59/organizations-92932930834-resource-1572993132795378.dump` stdout should match "gs://forseti-cai-export-a110fc59/organizations-92932930834-resource-1572993132795378.dump"
     ✔  Command: `forseti model delete 5fa33e291fd04686911c2c25445b5dac` exit_status should eq 0
     ✔  Command: `forseti inventory delete 1572993132795378` exit_status should eq 0


Profile Summary: 1 successful control, 0 control failures, 0 controls skipped
Test Summary: 3 successful, 0 failures, 0 skipped
       Finished verifying <forseti-local> (0m51.29s).
-----> Kitchen is finished. (0m53.48s)