### PR TITLE
Run e2e tests for master, release-*, and test/* branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,11 +35,12 @@ jobs:
     - docker -l error exec -it build /bin/bash -c "bash <(curl -s https://codecov.io/bash)"
   - stage: Integration test
     name: Integration test - docker
-    branches:
-      only:
-        - master
-        - /^release-.*$/
-        - /^test\/.*$/
+    if: (type = push AND branch = master) OR (branch =~ /^release-.*$/) OR (branch =~ /^test\/.*$/)
+#    branches:
+#      only:
+#        - master
+#        - /^release-.*$/
+#        - /^test\/.*$/
     services:
     - docker
     before_install:
@@ -50,6 +51,7 @@ jobs:
     - docker image pull gcr.io/cloud-foundation-cicd/cft/developer-tools:0.4.1
     script:
     - docker container run -it
+      -e TF_VAR_forseti_version=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
       -e KITCHEN_TEST_BASE_PATH="integration_tests/tests"
       -e SERVICE_ACCOUNT_JSON="$(< credentials.json)"
       --env-file travis-integration.env

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,11 @@ jobs:
     - docker -l error exec -it build /bin/bash -c "bash <(curl -s https://codecov.io/bash)"
   - stage: Integration test
     name: Integration test - docker
-    # Check on cron ensures build for integration tests is triggered only when
-    # cron job runs on master branch. This cron job is currently set to run daily.
-    if: type = cron
+    branches:
+      only:
+        - master
+        - /^release-.*$/
+        - /^test\/.*$/
     services:
     - docker
     before_install:
@@ -46,8 +48,6 @@ jobs:
     - tar xvf secret-key.tar
     install:
     - docker image pull gcr.io/cloud-foundation-cicd/cft/developer-tools:0.4.1
-    # Environment setup, tests execution and clean up is happening in
-    # /usr/local/bin/test_integration.sh
     script:
     - docker container run -it
       -e KITCHEN_TEST_BASE_PATH="integration_tests/tests"


### PR DESCRIPTION
Updating travis config to run e2e tests on master, release, and test branches.