### PR TITLE
Shorten test inventory names.

### DIFF
--- a/integration_tests/tests/forseti/controls/explain.rb
+++ b/integration_tests/tests/forseti/controls/explain.rb
@@ -15,7 +15,7 @@
 require 'securerandom'
 require 'json'
 
-random_string = SecureRandom.uuid.gsub!('-', '')
+random_string = SecureRandom.uuid.gsub!('-', '')[0..10]
 
 control "explain" do
   @inventory_id = /\"id\"\: \"([0-9]*)\"/.match(command("forseti inventory create --import_as #{random_string}").stdout)[1]

--- a/integration_tests/tests/forseti/controls/inventory-create.rb
+++ b/integration_tests/tests/forseti/controls/inventory-create.rb
@@ -22,7 +22,7 @@ if db_password.strip != ""
 end
 
 kms_resources_names = attribute('kms_resources_names')
-random_string = SecureRandom.uuid.gsub!('-', '')
+random_string = SecureRandom.uuid.gsub!('-', '')[0..10]
 
 control "inventory - create" do
   @inventory_id = /\"id\"\: \"([0-9]*)\"/.match(command("forseti inventory create --import_as #{random_string}").stdout)[1]

--- a/integration_tests/tests/forseti/controls/inventory-delete.rb
+++ b/integration_tests/tests/forseti/controls/inventory-delete.rb
@@ -20,7 +20,7 @@ db_password = attribute('db_password')
 if db_password.strip != ""
   db_password = "-p#{db_password}"
 end
-random_string = SecureRandom.uuid.gsub!('-', '')
+random_string = SecureRandom.uuid.gsub!('-', '')[0..10]
 
 control "inventory - delete" do
   @inventory_id = /\"id\"\: \"([0-9]*)\"/.match(command("forseti inventory create --import_as #{random_string}").stdout)[1]

--- a/integration_tests/tests/forseti/controls/inventory-get_and_list.rb
+++ b/integration_tests/tests/forseti/controls/inventory-get_and_list.rb
@@ -20,7 +20,7 @@ db_password = attribute('db_password')
 if db_password.strip != ""
   db_password = "-p#{db_password}"
 end
-random_string = SecureRandom.uuid.gsub!('-', '')
+random_string = SecureRandom.uuid.gsub!('-', '')[0..10]
 
 control "inventory - get" do
   @inventory_id = /\"id\"\: \"([0-9]*)\"/.match(command("forseti inventory create --import_as #{random_string}").stdout)[1]

--- a/integration_tests/tests/forseti/controls/inventory-purge.rb
+++ b/integration_tests/tests/forseti/controls/inventory-purge.rb
@@ -20,7 +20,7 @@ db_password = attribute('db_password')
 if db_password.strip != ""
   db_password = "-p#{db_password}"
 end
-random_string = SecureRandom.uuid.gsub!('-', '')
+random_string = SecureRandom.uuid.gsub!('-', '')[0..10]
 
 control "inventory - purge" do
   @inventory_id = /\"id\"\: \"([0-9]*)\"/.match(command("forseti inventory create --import_as #{random_string}").stdout)[1]

--- a/integration_tests/tests/forseti/controls/model-create_and_get.rb
+++ b/integration_tests/tests/forseti/controls/model-create_and_get.rb
@@ -20,7 +20,7 @@ db_password = attribute('db_password')
 if db_password.strip != ""
   db_password = "-p#{db_password}"
 end
-random_string = SecureRandom.uuid.gsub!('-', '')
+random_string = SecureRandom.uuid.gsub!('-', '')[0..10]
 
 control "model - create and get" do
   @inventory_id = /\"id\"\: \"([0-9]*)\"/.match(command("forseti inventory create --import_as #{random_string}").stdout)[1]

--- a/integration_tests/tests/forseti/controls/model-delete.rb
+++ b/integration_tests/tests/forseti/controls/model-delete.rb
@@ -20,7 +20,7 @@ db_password = attribute('db_password')
 if db_password.strip != ""
   db_password = "-p#{db_password}"
 end
-random_string = SecureRandom.uuid.gsub!('-', '')
+random_string = SecureRandom.uuid.gsub!('-', '')[0..10]
 
 control "model - delete" do
   @inventory_id = /\"id\"\: \"([0-9]*)\"/.match(command("forseti inventory create --import_as #{random_string}").stdout)[1]

--- a/integration_tests/tests/forseti/controls/model-list.rb
+++ b/integration_tests/tests/forseti/controls/model-list.rb
@@ -15,7 +15,7 @@
 require 'securerandom'
 require 'json'
 
-random_string = SecureRandom.uuid.gsub!('-', '')
+random_string = SecureRandom.uuid.gsub!('-', '')[0..10]
 
 control "model - list" do
   @inventory_id = /\"id\"\: \"([0-9]*)\"/.match(command("forseti inventory create --import_as #{random_string}").stdout)[1]

--- a/integration_tests/tests/forseti/controls/model-use.rb
+++ b/integration_tests/tests/forseti/controls/model-use.rb
@@ -15,7 +15,7 @@
 require 'securerandom'
 require 'json'
 
-random_string = SecureRandom.uuid.gsub!('-', '')
+random_string = SecureRandom.uuid.gsub!('-', '')[0..10]
 
 control "model - use" do
   @inventory_id = /\"id\"\: \"([0-9]*)\"/.match(command("forseti inventory create --import_as #{random_string}").stdout)[1]

--- a/integration_tests/tests/forseti/controls/scanner-db_no_errors.rb
+++ b/integration_tests/tests/forseti/controls/scanner-db_no_errors.rb
@@ -19,7 +19,7 @@ db_password = attribute('db_password')
 if db_password.strip != ""
   db_password = "-p#{db_password}"
 end
-random_string = SecureRandom.uuid.gsub!('-', '')
+random_string = SecureRandom.uuid.gsub!('-', '')[0..10]
 
 control "scanner - db no errors" do
   @inventory_id = /"id": "([0-9]*)"/.match(command("forseti inventory create --import_as #{random_string}").stdout)[1]

--- a/integration_tests/tests/forseti/controls/scanner-external_project_access.rb
+++ b/integration_tests/tests/forseti/controls/scanner-external_project_access.rb
@@ -15,7 +15,7 @@
 require 'securerandom'
 require 'json'
 
-random_string = SecureRandom.uuid.gsub!('-', '')
+random_string = SecureRandom.uuid.gsub!('-', '')[0..10]
 
 control "scanner - external project access" do
   @inventory_id = /\"id\"\: \"([0-9]*)\"/.match(command("forseti inventory create --import_as #{random_string}").stdout)[1]


### PR DESCRIPTION
Inventory names can't be too long. Shortening random strings to 10 characters for a name.