### PR TITLE
Additional explain tests

### DIFF
--- a/integration_tests/tests/forseti/controls/explain.rb
+++ b/integration_tests/tests/forseti/controls/explain.rb
@@ -16,6 +16,7 @@ require 'securerandom'
 require 'json'
 
 forseti_server_service_account = attribute('forseti-server-service-account')
+forseti_client_service_account = attribute('forseti-client-service-account')
 project_id = attribute('project_id')
 org_id = attribute('org_id')
 
@@ -44,6 +45,24 @@ control "explain" do
   describe command("forseti explainer get_policy project/#{project_id} | grep -c #{forseti_server_service_account}") do
     its('exit_status') { should eq 0 }
     its('stdout') { should match (/5/) }
+  end
+
+  # list_members
+  sa_client_service_account = "serviceaccount/#{forseti_client_service_account}"
+  sa_server_service_account = "serviceaccount/#{forseti_server_service_account}"
+  po_project_id = "projectowner/#{project_id}"
+  describe command("forseti explainer list_member") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should match (sa_client_service_account) }
+    its('stdout') { should match (sa_server_service_account) }
+    its('stdout') { should match (po_project_id) }
+  end
+
+  # list_members --prefix forseti
+  describe command("forseti explainer list_members --prefix forseti") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should match (sa_client_service_account) }
+    its('stdout') { should match (sa_server_service_account) }
   end
 
   # list_permissions roles/iam.roleAdmin

--- a/integration_tests/tests/forseti/controls/explain.rb
+++ b/integration_tests/tests/forseti/controls/explain.rb
@@ -32,7 +32,15 @@ control "explain" do
   # access_by_authz
   describe command("forseti explainer access_by_authz --permission iam.serviceAccounts.get") do
     its('exit_status') { should eq 0 }
-    its('stdout') { should match (/roles\/editor/) }
+    its('stdout') { should match (/"resource": "project\/#{project_id}"/) }
+    its('stdout') { should match (/"role": "roles\/editor"/) }
+  end
+
+  # access_by_authz
+  describe command("forseti explainer access_by_authz --role roles/storage.objectCreator") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should match (/#{project_id}/) }
+    its('stdout') { should match (/serviceaccount\/#{forseti_server_service_account}/) }
   end
 
   # access_by_resource organization
@@ -60,21 +68,18 @@ control "explain" do
   end
 
   # list_members
-  sa_client_service_account = "serviceaccount/#{forseti_client_service_account}"
-  sa_server_service_account = "serviceaccount/#{forseti_server_service_account}"
-  po_project_id = "projectowner/#{project_id}"
-  describe command("forseti explainer list_member") do
+  describe command("forseti explainer list_members") do
     its('exit_status') { should eq 0 }
-    its('stdout') { should match (sa_client_service_account) }
-    its('stdout') { should match (sa_server_service_account) }
-    its('stdout') { should match (po_project_id) }
+    its('stdout') { should match (/serviceaccount\/#{Regexp.quote(forseti_client_service_account)}/) }
+    its('stdout') { should match (/serviceaccount\/#{Regexp.quote(forseti_server_service_account)}/) }
+    its('stdout') { should match (/projectowner\/#{Regexp.quote(project_id)}/) }
   end
 
   # list_members --prefix forseti
   describe command("forseti explainer list_members --prefix forseti") do
     its('exit_status') { should eq 0 }
-    its('stdout') { should match (sa_client_service_account) }
-    its('stdout') { should match (sa_server_service_account) }
+    its('stdout') { should match (/serviceaccount\/#{Regexp.quote(forseti_client_service_account)}/) }
+    its('stdout') { should match (/serviceaccount\/#{Regexp.quote(forseti_server_service_account)}/) }
   end
 
   # list_permissions roles/iam.roleAdmin
@@ -223,7 +228,7 @@ control "explain" do
     its('exit_status') { should eq 0 }
     its('stdout') { should match (/organization\/#{Regexp.quote(org_id)}/) }
   end
-  
+
   # cleanup
   describe command("forseti inventory delete #{@inventory_id}") do
     its('exit_status') { should eq 0 }

--- a/integration_tests/tests/forseti/controls/explain.rb
+++ b/integration_tests/tests/forseti/controls/explain.rb
@@ -32,15 +32,15 @@ control "explain" do
   # access_by_member
   describe command("forseti explainer access_by_member serviceaccount/#{forseti_server_service_account}") do
     its('exit_status') { should eq 0 }
-    its('stdout') { should match (/"resources": [ "organization\/#{Regexp.quote(org_id)}" ], "role": "roles\/browser"/) }
-    its('stdout') { should match (/"resources": [ "organization\/#{Regexp.quote(org_id)}" ], "role": "roles\/iam.securityReviewer"/) }
-    its('stdout') { should match (/"resources": [ "project\/#{Regexp.quote(project_id)}" ], "role": "roles\/cloudsql.client"/) }
+    its('stdout') { should match (/"resources": \[\n    "organization\/#{Regexp.quote(org_id)}"\n  \],\n  "role": "roles\/browser"/) }
+    its('stdout') { should match (/"resources": \[\n    "organization\/#{Regexp.quote(org_id)}"\n  \],\n  "role": "roles\/iam.securityReviewer"/) }
+    its('stdout') { should match (/"resources": \[\n    "project\/#{Regexp.quote(project_id)}"\n  \],\n  "role": "roles\/cloudsql.client"/) }
   end
 
   # access_by_member storage.buckets.lists
   describe command("forseti explainer access_by_member serviceaccount/#{forseti_server_service_account} storage.buckets.list") do
     its('exit_status') { should eq 0 }
-    its('stdout') { should match (/"resources": [ "organization\/#{Regexp.quote(project_id)}" ], "role": "roles\/iam.securityReviewer"/) }
+    its('stdout') { should match (/"resources": \[\n    "organization\/#{Regexp.quote(org_id)}"\n  \],\n  "role": "roles\/iam.securityReviewer"/) }
   end
 
   # access_by_authz
@@ -248,7 +248,7 @@ control "explain" do
     its('exit_status') { should eq 0 }
     its('stdout') { should match (/\"result\": true/)}
   end
-  
+
   # cleanup
   describe command("forseti inventory delete #{@inventory_id}") do
     its('exit_status') { should eq 0 }

--- a/integration_tests/tests/forseti/controls/explain.rb
+++ b/integration_tests/tests/forseti/controls/explain.rb
@@ -173,11 +173,19 @@ control "explain" do
   # why_denied permission for org
   describe command("forseti explainer why_denied serviceaccount/#{forseti_server_service_account} organization/#{org_id} --role roles/resourcemanager.organizationAdmin") do
     its('exit_status') { should eq 0 }
+    its('stdout') { should match (forseti_server_service_account) }
+    its('stdout') { should match (forseti_server_service_account) }
+    its('stdout') { should match (/organization\/#{Regexp.quote(org_id)}/) }
+    its('stdout') { should match (/roles\/resourcemanager.organizationAdmin/) }
+    its('stdout') { should match (/"overgranting": 0/) }
   end
 
   # why_denied permission for project
   describe command("forseti explainer why_denied serviceaccount/#{forseti_server_service_account} project/#{project_id} --permission storage.buckets.delete") do
     its('exit_status') { should eq 0 }
+    its('stdout') { should match (/roles\/cloudmigration.inframanager/) }
+    its('stdout') { should match (/roles\/owner/) }
+    its('stdout') { should match (/roles\/storage.admin/) }
   end
 
   # why_granted permission for org

--- a/integration_tests/tests/forseti/controls/explain.rb
+++ b/integration_tests/tests/forseti/controls/explain.rb
@@ -170,6 +170,16 @@ control "explain" do
     its('stdout') { should match (/roles\/storagetransfer.viewer/) }
   end
 
+  # why_denied permission for org
+  describe command("forseti explainer why_denied serviceaccount/#{forseti_server_service_account} organization/#{org_id} --role roles/resourcemanager.organizationAdmin") do
+    its('exit_status') { should eq 0 }
+  end
+
+  # why_denied permission for project
+  describe command("forseti explainer why_denied serviceaccount/#{forseti_server_service_account} project/#{project_id} --permission storage.buckets.delete") do
+    its('exit_status') { should eq 0 }
+  end
+
   # why_granted permission for org
   describe command("forseti explainer why_granted serviceaccount/#{forseti_server_service_account} organization/#{org_id} --permission iam.serviceAccounts.get") do
     its('exit_status') { should eq 0 }

--- a/integration_tests/tests/forseti/controls/explain.rb
+++ b/integration_tests/tests/forseti/controls/explain.rb
@@ -35,6 +35,18 @@ control "explain" do
     its('stdout') { should match (/roles\/editor/) }
   end
 
+  # access_by_resource organization
+  describe command("forseti explainer access_by_resource organization/#{org_id} | grep -c #{forseti_server_service_account}") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should match (/10/) }
+  end
+
+  # access_by_resource project
+  describe command("forseti explainer access_by_resource project/#{project_id} | grep -c #{forseti_server_service_account}") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should match (/5/) }
+  end
+
   # get_policy for org
   describe command("forseti explainer get_policy organization/#{org_id} | grep -c #{forseti_server_service_account}") do
     its('exit_status') { should eq 0 }
@@ -63,20 +75,6 @@ control "explain" do
     its('exit_status') { should eq 0 }
     its('stdout') { should match (sa_client_service_account) }
     its('stdout') { should match (sa_server_service_account) }
-  end
-
-  # access_by_member
-  describe command("forseti explainer access_by_member serviceaccount/#{forseti_server_service_account}") do
-    its('exit_status') { should eq 0 }
-    its('stdout') { should match (/"resources": [ "organization\/#{Regexp.quote(org_id)}" ], "role": "roles\/browser"/) }
-    its('stdout') { should match (/"resources": [ "organization\/#{Regexp.quote(org_id)}" ], "role": "roles\/iam.securityReviewer"/) }
-    its('stdout') { should match (/"resources": [ "project\/#{Regexp.quote(project_id)}" ], "role": "roles\/cloudsql.client"/) }
-  end
-
-  # access_by_member storage.buckets.lists
-  describe command("forseti explainer access_by_member serviceaccount/#{forseti_server_service_account} storage.buckets.list") do
-    its('exit_status') { should eq 0 }
-    its('stdout') { should match (/"resources": [ "organization\/#{Regexp.quote(project_id)}" ], "role": "roles\/iam.securityReviewer"/) }
   end
 
   # list_permissions roles/iam.roleAdmin

--- a/integration_tests/tests/forseti/controls/explain.rb
+++ b/integration_tests/tests/forseti/controls/explain.rb
@@ -29,6 +29,20 @@ control "explain" do
     its('exit_status') { should eq 0 }
   end
 
+  # access_by_member
+  describe command("forseti explainer access_by_member serviceaccount/#{forseti_server_service_account}") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should match (/"resources": [ "organization\/#{Regexp.quote(org_id)}" ], "role": "roles\/browser"/) }
+    its('stdout') { should match (/"resources": [ "organization\/#{Regexp.quote(org_id)}" ], "role": "roles\/iam.securityReviewer"/) }
+    its('stdout') { should match (/"resources": [ "project\/#{Regexp.quote(project_id)}" ], "role": "roles\/cloudsql.client"/) }
+  end
+
+  # access_by_member storage.buckets.lists
+  describe command("forseti explainer access_by_member serviceaccount/#{forseti_server_service_account} storage.buckets.list") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should match (/"resources": [ "organization\/#{Regexp.quote(project_id)}" ], "role": "roles\/iam.securityReviewer"/) }
+  end
+
   # access_by_authz
   describe command("forseti explainer access_by_authz --permission iam.serviceAccounts.get") do
     its('exit_status') { should eq 0 }

--- a/integration_tests/tests/forseti/controls/explain.rb
+++ b/integration_tests/tests/forseti/controls/explain.rb
@@ -65,6 +65,20 @@ control "explain" do
     its('stdout') { should match (sa_server_service_account) }
   end
 
+  # access_by_member
+  describe command("forseti explainer access_by_member serviceaccount/#{forseti_server_service_account}") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should match (/"resources": [ "organization\/#{Regexp.quote(org_id)}" ], "role": "roles\/browser"/) }
+    its('stdout') { should match (/"resources": [ "organization\/#{Regexp.quote(org_id)}" ], "role": "roles\/iam.securityReviewer"/) }
+    its('stdout') { should match (/"resources": [ "project\/#{Regexp.quote(project_id)}" ], "role": "roles\/cloudsql.client"/) }
+  end
+
+  # access_by_member storage.buckets.lists
+  describe command("forseti explainer access_by_member serviceaccount/#{forseti_server_service_account} storage.buckets.list") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should match (/"resources": [ "organization\/#{Regexp.quote(project_id)}" ], "role": "roles\/iam.securityReviewer"/) }
+  end
+
   # list_permissions roles/iam.roleAdmin
   describe command("forseti explainer list_permissions --roles roles/iam.roleAdmin") do
     its('exit_status') { should eq 0 }


### PR DESCRIPTION
[root@38a20814a542 workspace]# kitchen verify --test-base-path="integration_tests/tests"
-----> Starting Kitchen (v1.24.0)
-----> Verifying <forseti-local>...
$$$$$$ Running command `terraform workspace select kitchen-terraform-forseti-local` in directory /workspace/integration_tests/fixtures/forseti
$$$$$$ Running command `terraform output -json` in directory /workspace/integration_tests/fixtures/forseti
inventory-module: Verifying host 10.128.0.10
Skipping profile: 'inspec-gcp' on unsupported platform: 'ubuntu/18.04'.
...........................................................................................................................

Profile: forseti_integration_testing
Version: (not specified)
Target:  ssh://ubuntu@10.128.0.10:22

  ✔  explain: Command: `forseti model use 897cef3e9a1`
     ✔  Command: `forseti model use 897cef3e9a1` exit_status should eq 0
     ✔  Command: `forseti explainer access_by_authz --permission iam.serviceAccounts.get` exit_status should eq 0
     ✔  Command: `forseti explainer access_by_authz --permission iam.serviceAccounts.get` stdout should match /"resource": "project\/va-test-project-256619"/
     ✔  Command: `forseti explainer access_by_authz --permission iam.serviceAccounts.get` stdout should match /"role": "roles\/editor"/
     ✔  Command: `forseti explainer access_by_authz --role roles/storage.objectCreator` exit_status should eq 0
     ✔  Command: `forseti explainer access_by_authz --role roles/storage.objectCreator` stdout should match /va-test-project-256619/
     ✔  Command: `forseti explainer access_by_authz --role roles/storage.objectCreator` stdout should match /serviceaccount\/forseti-server-gcp-fb135779@va-test-project-256619.iam.gserviceaccount.com/
     ✔  Command: `forseti explainer access_by_resource organization/92932930834 | grep -c forseti-server-gcp-fb135779@va-test-project-256619.iam.gserviceaccount.com` exit_status should eq 0
     ✔  Command: `forseti explainer access_by_resource organization/92932930834 | grep -c forseti-server-gcp-fb135779@va-test-project-256619.iam.gserviceaccount.com` stdout should match /10/
     ✔  Command: `forseti explainer access_by_resource project/va-test-project-256619 | grep -c forseti-server-gcp-fb135779@va-test-project-256619.iam.gserviceaccount.com` exit_status should eq 0
     ✔  Command: `forseti explainer access_by_resource project/va-test-project-256619 | grep -c forseti-server-gcp-fb135779@va-test-project-256619.iam.gserviceaccount.com` stdout should match /5/
     ✔  Command: `forseti explainer get_policy organization/92932930834 | grep -c forseti-server-gcp-fb135779@va-test-project-256619.iam.gserviceaccount.com` exit_status should eq 0
     ✔  Command: `forseti explainer get_policy organization/92932930834 | grep -c forseti-server-gcp-fb135779@va-test-project-256619.iam.gserviceaccount.com` stdout should match /10/
     ✔  Command: `forseti explainer get_policy project/va-test-project-256619 | grep -c forseti-server-gcp-fb135779@va-test-project-256619.iam.gserviceaccount.com` exit_status should eq 0
     ✔  Command: `forseti explainer get_policy project/va-test-project-256619 | grep -c forseti-server-gcp-fb135779@va-test-project-256619.iam.gserviceaccount.com` stdout should match /5/
     ✔  Command: `forseti explainer list_members` exit_status should eq 0
     ✔  Command: `forseti explainer list_members` stdout should match /serviceaccount\/forseti\-client\-gcp\-fb135779@va\-test\-project\-256619\.iam\.gserviceaccount\.com/
     ✔  Command: `forseti explainer list_members` stdout should match /serviceaccount\/forseti\-server\-gcp\-fb135779@va\-test\-project\-256619\.iam\.gserviceaccount\.com/
     ✔  Command: `forseti explainer list_members` stdout should match /projectowner\/va\-test\-project\-256619/
     ✔  Command: `forseti explainer list_members --prefix forseti` exit_status should eq 0
     ✔  Command: `forseti explainer list_members --prefix forseti` stdout should match /serviceaccount\/forseti\-client\-gcp\-fb135779@va\-test\-project\-256619\.iam\.gserviceaccount\.com/
     ✔  Command: `forseti explainer list_members --prefix forseti` stdout should match /serviceaccount\/forseti\-server\-gcp\-fb135779@va\-test\-project\-256619\.iam\.gserviceaccount\.com/
     ✔  Command: `forseti explainer list_permissions --roles roles/iam.roleAdmin` exit_status should eq 0
     ✔  Command: `forseti explainer list_permissions --roles roles/iam.roleAdmin` stdout should match /iam.roles.create/
     ✔  Command: `forseti explainer list_permissions --roles roles/iam.roleAdmin` stdout should match /iam.roles.delete/
     ✔  Command: `forseti explainer list_permissions --roles roles/iam.roleAdmin` stdout should match /iam.roles.get/
     ✔  Command: `forseti explainer list_permissions --roles roles/iam.roleAdmin` stdout should match /iam.roles.list/
     ✔  Command: `forseti explainer list_permissions --roles roles/iam.roleAdmin` stdout should match /iam.roles.undelete/
     ✔  Command: `forseti explainer list_permissions --roles roles/iam.roleAdmin` stdout should match /iam.roles.update/
     ✔  Command: `forseti explainer list_permissions --roles roles/iam.roleAdmin` stdout should match /resourcemanager.projects.get/
     ✔  Command: `forseti explainer list_permissions --roles roles/iam.roleAdmin` stdout should match /resourcemanager.projects.getIamPolicy/
     ✔  Command: `forseti explainer list_permissions --roles roles/storage.admin` exit_status should eq 0
     ✔  Command: `forseti explainer list_permissions --roles roles/storage.admin` stdout should match /storage.buckets.create/
     ✔  Command: `forseti explainer list_permissions --roles roles/storage.admin` stdout should match /storage.buckets.delete/
     ✔  Command: `forseti explainer list_permissions --roles roles/storage.admin` stdout should match /storage.buckets.get/
     ✔  Command: `forseti explainer list_permissions --roles roles/storage.admin` stdout should match /storage.buckets.getIamPolicy/
     ✔  Command: `forseti explainer list_permissions --roles roles/storage.admin` stdout should match /storage.buckets.list/
     ✔  Command: `forseti explainer list_permissions --roles roles/storage.admin` stdout should match /storage.buckets.setIamPolicy/
     ✔  Command: `forseti explainer list_permissions --roles roles/storage.admin` stdout should match /storage.buckets.update/
     ✔  Command: `forseti explainer list_permissions --roles roles/storage.admin` stdout should match /storage.objects.create/
     ✔  Command: `forseti explainer list_permissions --roles roles/storage.admin` stdout should match /storage.objects.delete/
     ✔  Command: `forseti explainer list_permissions --roles roles/storage.admin` stdout should match /storage.objects.get/
     ✔  Command: `forseti explainer list_permissions --roles roles/storage.admin` stdout should match /storage.objects.getIamPolicy/
     ✔  Command: `forseti explainer list_permissions --roles roles/storage.admin` stdout should match /storage.objects.list/
     ✔  Command: `forseti explainer list_permissions --roles roles/storage.admin` stdout should match /storage.objects.setIamPolicy/
     ✔  Command: `forseti explainer list_permissions --roles roles/storage.admin` stdout should match /storage.objects.update/
     ✔  Command: `forseti explainer list_permissions --role_prefixes roles/storage` exit_status should eq 0
     ✔  Command: `forseti explainer list_permissions --role_prefixes roles/storage` stdout should match /roles\/storage.admin/
     ✔  Command: `forseti explainer list_permissions --role_prefixes roles/storage` stdout should match /roles\/storage.hmacKeyAdmin/
     ✔  Command: `forseti explainer list_permissions --role_prefixes roles/storage` stdout should match /roles\/storage.legacyBucketOwner/
     ✔  Command: `forseti explainer list_permissions --role_prefixes roles/storage` stdout should match /roles\/storage.legacyBucketReader/
     ✔  Command: `forseti explainer list_permissions --role_prefixes roles/storage` stdout should match /roles\/storage.legacyBucketWriter/
     ✔  Command: `forseti explainer list_permissions --role_prefixes roles/storage` stdout should match /roles\/storage.legacyObjectOwner/
     ✔  Command: `forseti explainer list_permissions --role_prefixes roles/storage` stdout should match /roles\/storage.legacyObjectReader/
     ✔  Command: `forseti explainer list_permissions --role_prefixes roles/storage` stdout should match /roles\/storage.objectAdmin/
     ✔  Command: `forseti explainer list_permissions --role_prefixes roles/storage` stdout should match /roles\/storage.objectCreator/
     ✔  Command: `forseti explainer list_permissions --role_prefixes roles/storage` stdout should match /roles\/storage.objectViewer/
     ✔  Command: `forseti explainer list_permissions --role_prefixes roles/storage` stdout should match /roles\/storagetransfer.admin/
     ✔  Command: `forseti explainer list_permissions --role_prefixes roles/storage` stdout should match /roles\/storagetransfer.user/
     ✔  Command: `forseti explainer list_permissions --role_prefixes roles/storage` stdout should match /roles\/storagetransfer.viewer/
     ✔  Command: `forseti explainer list_roles` exit_status should eq 0
     ✔  Command: `forseti explainer list_roles` stdout should match /roles\/cloudtrace.user/
     ✔  Command: `forseti explainer list_roles` stdout should match /roles\/compute.admin/
     ✔  Command: `forseti explainer list_roles` stdout should match /roles\/storage.objectAdmin/
     ✔  Command: `forseti explainer list_roles` stdout should match /roles\/stackdriver.accounts.viewer/
     ✔  Command: `forseti explainer list_roles` stdout should match /roles\/serviceusage.serviceUsageViewer/
     ✔  Command: `forseti explainer list_roles` stdout should match /roles\/servicemanagement.quotaAdmin/
     ✔  Command: `forseti explainer list_roles` stdout should match /roles\/securitycenter.sourcesEditor/
     ✔  Command: `forseti explainer list_roles` stdout should match /roles\/securitycenter.findingsStateSetter/
     ✔  Command: `forseti explainer list_roles` stdout should match /roles\/securitycenter.findingsEditor/
     ✔  Command: `forseti explainer list_roles` stdout should match /roles\/pubsub.editor/
     ✔  Command: `forseti explainer list_roles` stdout should match /roles\/monitoring.viewer/
     ✔  Command: `forseti explainer list_roles` stdout should match /roles\/container.clusterViewer/
     ✔  Command: `forseti explainer list_roles` stdout should match /roles\/dataflow.worker/
     ✔  Command: `forseti explainer list_roles` stdout should match /roles\/datastore.viewer/
     ✔  Command: `forseti explainer list_roles --prefix roles/iam` exit_status should eq 0
     ✔  Command: `forseti explainer list_roles --prefix roles/iam` stdout should match /roles\/iam.organizationRoleAdmin/
     ✔  Command: `forseti explainer list_roles --prefix roles/iam` stdout should match /roles\/iam.organizationRoleViewer/
     ✔  Command: `forseti explainer list_roles --prefix roles/iam` stdout should match /roles\/iam.roleAdmin/
     ✔  Command: `forseti explainer list_roles --prefix roles/iam` stdout should match /roles\/iam.roleViewer/
     ✔  Command: `forseti explainer list_roles --prefix roles/iam` stdout should match /roles\/iam.securityAdmin/
     ✔  Command: `forseti explainer list_roles --prefix roles/iam` stdout should match /roles\/iam.securityReviewer/
     ✔  Command: `forseti explainer list_roles --prefix roles/iam` stdout should match /roles\/iam.serviceAccountAdmin/
     ✔  Command: `forseti explainer list_roles --prefix roles/iam` stdout should match /roles\/iam.serviceAccountCreator/
     ✔  Command: `forseti explainer list_roles --prefix roles/iam` stdout should match /roles\/iam.serviceAccountDeleter/
     ✔  Command: `forseti explainer list_roles --prefix roles/iam` stdout should match /roles\/iam.serviceAccountKeyAdmin/
     ✔  Command: `forseti explainer list_roles --prefix roles/iam` stdout should match /roles\/iam.serviceAccountTokenCreator/
     ✔  Command: `forseti explainer list_roles --prefix roles/iam` stdout should match /roles\/iam.serviceAccountUser/
     ✔  Command: `forseti explainer list_roles --prefix roles/iam` stdout should match /roles\/iam.workloadIdentityUser/
     ✔  Command: `forseti explainer list_roles --prefix roles/storage` exit_status should eq 0
     ✔  Command: `forseti explainer list_roles --prefix roles/storage` stdout should match /roles\/storage.admin/
     ✔  Command: `forseti explainer list_roles --prefix roles/storage` stdout should match /roles\/storage.hmacKeyAdmin/
     ✔  Command: `forseti explainer list_roles --prefix roles/storage` stdout should match /roles\/storage.legacyBucketOwner/
     ✔  Command: `forseti explainer list_roles --prefix roles/storage` stdout should match /roles\/storage.legacyBucketReader/
     ✔  Command: `forseti explainer list_roles --prefix roles/storage` stdout should match /roles\/storage.legacyBucketWriter/
     ✔  Command: `forseti explainer list_roles --prefix roles/storage` stdout should match /roles\/storage.legacyObjectOwner/
     ✔  Command: `forseti explainer list_roles --prefix roles/storage` stdout should match /roles\/storage.legacyObjectReader/
     ✔  Command: `forseti explainer list_roles --prefix roles/storage` stdout should match /roles\/storage.objectAdmin/
     ✔  Command: `forseti explainer list_roles --prefix roles/storage` stdout should match /roles\/storage.objectCreator/
     ✔  Command: `forseti explainer list_roles --prefix roles/storage` stdout should match /roles\/storage.objectViewer/
     ✔  Command: `forseti explainer list_roles --prefix roles/storage` stdout should match /roles\/storagetransfer.admin/
     ✔  Command: `forseti explainer list_roles --prefix roles/storage` stdout should match /roles\/storagetransfer.user/
     ✔  Command: `forseti explainer list_roles --prefix roles/storage` stdout should match /roles\/storagetransfer.viewer/
     ✔  Command: `forseti explainer why_denied serviceaccount/forseti-server-gcp-fb135779@va-test-project-256619.iam.gserviceaccount.com organization/92932930834 --role roles/resourcemanager.organizationAdmin` exit_status should eq 0
     ✔  Command: `forseti explainer why_denied serviceaccount/forseti-server-gcp-fb135779@va-test-project-256619.iam.gserviceaccount.com organization/92932930834 --role roles/resourcemanager.organizationAdmin` stdout should match "forseti-server-gcp-fb135779@va-test-project-256619.iam.gserviceaccount.com"
     ✔  Command: `forseti explainer why_denied serviceaccount/forseti-server-gcp-fb135779@va-test-project-256619.iam.gserviceaccount.com organization/92932930834 --role roles/resourcemanager.organizationAdmin` stdout should match "forseti-server-gcp-fb135779@va-test-project-256619.iam.gserviceaccount.com"
     ✔  Command: `forseti explainer why_denied serviceaccount/forseti-server-gcp-fb135779@va-test-project-256619.iam.gserviceaccount.com organization/92932930834 --role roles/resourcemanager.organizationAdmin` stdout should match /organization\/92932930834/
     ✔  Command: `forseti explainer why_denied serviceaccount/forseti-server-gcp-fb135779@va-test-project-256619.iam.gserviceaccount.com organization/92932930834 --role roles/resourcemanager.organizationAdmin` stdout should match /roles\/resourcemanager.organizationAdmin/
     ✔  Command: `forseti explainer why_denied serviceaccount/forseti-server-gcp-fb135779@va-test-project-256619.iam.gserviceaccount.com organization/92932930834 --role roles/resourcemanager.organizationAdmin` stdout should match /"overgranting": 0/
     ✔  Command: `forseti explainer why_denied serviceaccount/forseti-server-gcp-fb135779@va-test-project-256619.iam.gserviceaccount.com project/va-test-project-256619 --permission storage.buckets.delete` exit_status should eq 0
     ✔  Command: `forseti explainer why_denied serviceaccount/forseti-server-gcp-fb135779@va-test-project-256619.iam.gserviceaccount.com project/va-test-project-256619 --permission storage.buckets.delete` stdout should match /roles\/cloudmigration.inframanager/
     ✔  Command: `forseti explainer why_denied serviceaccount/forseti-server-gcp-fb135779@va-test-project-256619.iam.gserviceaccount.com project/va-test-project-256619 --permission storage.buckets.delete` stdout should match /roles\/owner/
     ✔  Command: `forseti explainer why_denied serviceaccount/forseti-server-gcp-fb135779@va-test-project-256619.iam.gserviceaccount.com project/va-test-project-256619 --permission storage.buckets.delete` stdout should match /roles\/storage.admin/
     ✔  Command: `forseti explainer why_granted serviceaccount/forseti-server-gcp-fb135779@va-test-project-256619.iam.gserviceaccount.com organization/92932930834 --permission iam.serviceAccounts.get` exit_status should eq 0
     ✔  Command: `forseti explainer why_granted serviceaccount/forseti-server-gcp-fb135779@va-test-project-256619.iam.gserviceaccount.com organization/92932930834 --permission iam.serviceAccounts.get` stdout should match /roles\/iam.securityReviewer/
     ✔  Command: `forseti explainer why_granted serviceaccount/forseti-server-gcp-fb135779@va-test-project-256619.iam.gserviceaccount.com project/va-test-project-256619 --permission compute.instances.get` exit_status should eq 0
     ✔  Command: `forseti explainer why_granted serviceaccount/forseti-server-gcp-fb135779@va-test-project-256619.iam.gserviceaccount.com project/va-test-project-256619 --permission compute.instances.get` stdout should match /roles\/compute.networkViewer/
     ✔  Command: `forseti explainer why_granted serviceaccount/forseti-server-gcp-fb135779@va-test-project-256619.iam.gserviceaccount.com organization/92932930834 --role roles/iam.securityReviewer` exit_status should eq 0
     ✔  Command: `forseti explainer why_granted serviceaccount/forseti-server-gcp-fb135779@va-test-project-256619.iam.gserviceaccount.com organization/92932930834 --role roles/iam.securityReviewer` stdout should match /organization\/92932930834/
     ✔  Command: `forseti explainer why_granted serviceaccount/forseti-server-gcp-fb135779@va-test-project-256619.iam.gserviceaccount.com project/va-test-project-256619 --role roles/compute.networkViewer` exit_status should eq 0
     ✔  Command: `forseti explainer why_granted serviceaccount/forseti-server-gcp-fb135779@va-test-project-256619.iam.gserviceaccount.com project/va-test-project-256619 --role roles/compute.networkViewer` stdout should match /organization\/92932930834/
     ✔  Command: `forseti inventory delete 1574336313944098` exit_status should eq 0
     ✔  Command: `forseti model delete 897cef3e9a1` exit_status should eq 0


Profile Summary: 1 successful control, 0 control failures, 0 controls skipped
Test Summary: 123 successful, 0 failures, 0 skipped
       Finished verifying <forseti-local> (1m13.21s).
-----> Kitchen is finished. (1m15.30s)