### PR TITLE
Target Jekyll CommonMark gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,4 +16,5 @@ group :jekyll_plugins do
   gem 'jekyll-redirect-from'
   gem 'jekyll-responsive-image'
   gem 'jekyll-include-cache'
+  gem 'jekyll-commonmark'
 end

--- a/_config.yml
+++ b/_config.yml
@@ -42,7 +42,7 @@ plugins:
   - jekyll-include-cache
 google_analytics: UA-98416450-1
 highlighter: rouge
-markdown: CommonMark
+markdown: kramdown
 destination: _www/www/
 
 # Needed for local builds and using {{ site.github }}.

--- a/_config.yml
+++ b/_config.yml
@@ -42,7 +42,7 @@ plugins:
   - jekyll-include-cache
 google_analytics: UA-98416450-1
 highlighter: rouge
-markdown: kramdown
+markdown: CommonMark
 destination: _www/www/
 
 # Needed for local builds and using {{ site.github }}.


### PR DESCRIPTION
Use `jekyll-commonmark` because it is faster than Kramdown. Compared `--profile` results after using `jekyll-commonmark`; shows improvement in website build performance.