### PR TITLE
Fix CV Scanner after deletion of the rules directory

### DIFF
--- a/google/cloud/forseti/scanner/scanner_builder.py
+++ b/google/cloud/forseti/scanner/scanner_builder.py
@@ -111,29 +111,31 @@ class ScannerBuilder(object):
             LOGGER.exception('Unable to instantiate %s', class_name)
             return None
 
+        rules_path = ''
         rules_filename = (scanner_requirements_map.REQUIREMENTS_MAP
                           .get(scanner_name)
                           .get('rules_filename'))
 
-        rules_path = self.scanner_configs.get('rules_path')
-        if rules_path is None:
-            scanner_path = inspect.getfile(scanner_class)
-            rules_path = scanner_path.split('/google/cloud/forseti')[0]
-            rules_path += '/rules'
-        rules = '{}/{}'.format(rules_path, rules_filename)
+        if rules_filename:
+            rules_directory = self.scanner_configs.get('rules_path')
+            if rules_directory is None:
+                scanner_path = inspect.getfile(scanner_class)
+                rules_directory = scanner_path.split('/google/cloud/forseti')[0]
+                rules_directory += '/rules'
+            rules_path = '{}/{}'.format(rules_directory, rules_filename)
 
-        if not os.path.isfile(rules):
-            LOGGER.error(f'Rules file for Scanner {scanner_name} does not '
-                         f'exist. Rules path: {rules}')
-            return None
+            if not os.path.isfile(rules_path):
+                LOGGER.error(f'Rules file for Scanner {scanner_name} does not '
+                             f'exist. Rules path: {rules_path}')
+                return None
 
         LOGGER.info('Initializing the rules engine:\nUsing rules: %s',
-                    rules)
+                    rules_path)
 
         scanner = scanner_class(self.global_configs,
                                 self.scanner_configs,
                                 self.service_config,
                                 self.model_name,
                                 self.snapshot_timestamp,
-                                rules)
+                                rules_path)
         return scanner

--- a/tests/scanner/scanner_builder_test.py
+++ b/tests/scanner/scanner_builder_test.py
@@ -61,6 +61,17 @@ class ScannerBuilderTest(ForsetiTestCase):
         for pipeline in runnable_pipelines:
             self.assertTrue(type(pipeline).__name__ in expected_pipelines)
 
+    def testConfigValidator(self):
+        builder = scanner_builder.ScannerBuilder(
+            FAKE_GLOBAL_CONFIGS, fake_runnable_scanners.CONFIG_VALIDATOR_ENABLED,
+            mock.MagicMock(), '', FAKE_TIMESTAMP)
+        runnable_pipelines = builder.build()
+
+        self.assertEqual(1, len(runnable_pipelines))
+        expected_pipelines = ['ConfigValidatorScanner']
+        for pipeline in runnable_pipelines:
+            self.assertTrue(type(pipeline).__name__ in expected_pipelines)
+
     def testAllDisabled(self):
         builder = scanner_builder.ScannerBuilder(
             FAKE_GLOBAL_CONFIGS, fake_runnable_scanners.ALL_DISABLED,

--- a/tests/scanner/test_data/fake_runnable_scanners.py
+++ b/tests/scanner/test_data/fake_runnable_scanners.py
@@ -31,6 +31,13 @@ ALL_ENABLED = {
 
 ALL_DISABLED = {'scanners': []}
 
+
+CONFIG_VALIDATOR_ENABLED = {
+    'rules_path': test_rules_path,
+    'scanners': [
+        {'name': 'config_validator', 'enabled': True}
+    ]}
+
 ONE_ENABLED = {
     'rules_path': test_rules_path,
     'scanners': [


### PR DESCRIPTION
[After deleting the rules directory from the repo](https://github.com/forseti-security/forseti-security/pull/3479), the CV scanner was not working properly because Forseti will not run a scanner without an existing rules file. The CV scanner does not require a rules file. This change will allow any scanner to run without a rules file.