### PR TITLE
Update tests to use DB username and password outputs

### DIFF
--- a/build/e2e.cloudbuild.yaml
+++ b/build/e2e.cloudbuild.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-timeout: 3600s
+timeout: 7200s
 steps:
 - id: run_e2e_tests
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'

--- a/integration_tests/fixtures/forseti/outputs.tf
+++ b/integration_tests/fixtures/forseti/outputs.tf
@@ -43,6 +43,17 @@ output "forseti-client-storage-bucket" {
   value       = module.forseti.forseti-client-storage-bucket
 }
 
+output "forseti-cloudsql-password" {
+  description = "CloudSQL password"
+  value       = module.forseti.forseti-cloudsql-password
+  sensitive   = true
+}
+
+output "forseti-cloudsql-user" {
+  description = "CloudSQL user"
+  value       = module.forseti.forseti-cloudsql-user
+}
+
 output "forseti-server-vm-ip" {
   description = "Forseti Server VM private IP address"
   value       = module.forseti.forseti-server-vm-ip

--- a/integration_tests/tests/forseti/controls/inventory-create.rb
+++ b/integration_tests/tests/forseti/controls/inventory-create.rb
@@ -15,12 +15,8 @@
 require 'securerandom'
 require 'json'
 
-db_user_name = attribute('db_user_name')
-db_password = attribute('db_password')
-if db_password.strip != ""
-  db_password = "-p#{db_password}"
-end
-
+db_user_name = attribute('forseti-cloudsql-user')
+db_password = attribute('forseti-cloudsql-password')
 kms_resources_names = attribute('kms_resources_names')
 random_string = SecureRandom.uuid.gsub!('-', '')[0..10]
 
@@ -31,17 +27,17 @@ control "inventory-create" do
     its('exit_status') { should eq 0 }
   end
 
-  describe command("mysql -u #{db_user_name} #{db_password} --host 127.0.0.1 --database forseti_security --execute \"select COUNT(DISTINCT gcp_inventory.inventory_index_id) from gcp_inventory join inventory_index ON inventory_index.id = gcp_inventory.inventory_index_id where inventory_index.id = #{@inventory_id};\"") do
+  describe command("mysql -u #{db_user_name} -p#{db_password} --host 127.0.0.1 --database forseti_security --execute \"select COUNT(DISTINCT gcp_inventory.inventory_index_id) from gcp_inventory join inventory_index ON inventory_index.id = gcp_inventory.inventory_index_id where inventory_index.id = #{@inventory_id};\"") do
     its('exit_status') { should eq 0 }
     its('stdout') { should match (/1/)}
   end
 
-  describe command("mysql -u #{db_user_name} #{db_password} --host 127.0.0.1 --database forseti_security --execute \"SELECT count(DISTINCT resource_data->>'$.lifecycleState') FROM gcp_inventory WHERE category = 'resource' and resource_type = 'project' and resource_data->>'$.lifecycleState' = 'ACTIVE';\"") do
+  describe command("mysql -u #{db_user_name} -p#{db_password} --host 127.0.0.1 --database forseti_security --execute \"SELECT count(DISTINCT resource_data->>'$.lifecycleState') FROM gcp_inventory WHERE category = 'resource' and resource_type = 'project' and resource_data->>'$.lifecycleState' = 'ACTIVE';\"") do
     its('exit_status') { should eq 0 }
     its('stdout') { should match (/1/)}
   end
 
-  describe command("mysql -u #{db_user_name} #{db_password} --host 127.0.0.1 --database forseti_security --execute \"SELECT count(DISTINCT resource_type) from gcp_inventory where resource_type in ('kms_cryptokey', 'kms_keyring');\"") do
+  describe command("mysql -u #{db_user_name} -p#{db_password} --host 127.0.0.1 --database forseti_security --execute \"SELECT count(DISTINCT resource_type) from gcp_inventory where resource_type in ('kms_cryptokey', 'kms_keyring');\"") do
     its('exit_status') { should eq 0 }
     its('stdout') { should match (/#{kms_resources_names.count}/)}
   end

--- a/integration_tests/tests/forseti/controls/inventory-delete.rb
+++ b/integration_tests/tests/forseti/controls/inventory-delete.rb
@@ -15,11 +15,8 @@
 require 'securerandom'
 require 'json'
 
-db_user_name = attribute('db_user_name')
-db_password = attribute('db_password')
-if db_password.strip != ""
-  db_password = "-p#{db_password}"
-end
+db_user_name = attribute('forseti-cloudsql-user')
+db_password = attribute('forseti-cloudsql-password')
 random_string = SecureRandom.uuid.gsub!('-', '')[0..10]
 
 control "inventory-delete" do
@@ -29,7 +26,7 @@ control "inventory-delete" do
     its('exit_status') { should eq 0 }
   end
 
-  describe command("mysql -u #{db_user_name} #{db_password} --host 127.0.0.1 --database forseti_security --execute \"select count(DISTINCT gcp_inventory.inventory_index_id) from gcp_inventory join inventory_index on inventory_index.id = gcp_inventory.inventory_index_id where inventory_index.id = #{@inventory_id};\"") do
+  describe command("mysql -u #{db_user_name} -p#{db_password} --host 127.0.0.1 --database forseti_security --execute \"select count(DISTINCT gcp_inventory.inventory_index_id) from gcp_inventory join inventory_index on inventory_index.id = gcp_inventory.inventory_index_id where inventory_index.id = #{@inventory_id};\"") do
     its('exit_status') { should eq 0 }
     its('stdout') { should match (/1/)}
   end
@@ -42,7 +39,7 @@ control "inventory-delete" do
     its('exit_status') { should eq 0 }
   end
 
-  describe command("mysql -u #{db_user_name} #{db_password} --host 127.0.0.1 --database forseti_security --execute \"select count(DISTINCT gcp_inventory.inventory_index_id) from gcp_inventory join inventory_index on inventory_index.id = gcp_inventory.inventory_index_id where inventory_index.id = #{@inventory_id};\"") do
+  describe command("mysql -u #{db_user_name} -p#{db_password} --host 127.0.0.1 --database forseti_security --execute \"select count(DISTINCT gcp_inventory.inventory_index_id) from gcp_inventory join inventory_index on inventory_index.id = gcp_inventory.inventory_index_id where inventory_index.id = #{@inventory_id};\"") do
     its('exit_status') { should eq 0 }
     its('stdout') { should match (/0/)}
   end

--- a/integration_tests/tests/forseti/controls/inventory-get_and_list.rb
+++ b/integration_tests/tests/forseti/controls/inventory-get_and_list.rb
@@ -15,11 +15,8 @@
 require 'securerandom'
 require 'json'
 
-db_user_name = attribute('db_user_name')
-db_password = attribute('db_password')
-if db_password.strip != ""
-  db_password = "-p#{db_password}"
-end
+db_user_name = attribute('forseti-cloudsql-user')
+db_password = attribute('forseti-cloudsql-password')
 random_string = SecureRandom.uuid.gsub!('-', '')[0..10]
 
 control "inventory-get-list" do
@@ -39,7 +36,7 @@ control "inventory-get-list" do
     its('stdout') { should match (/#{@inventory_id}/)}
   end
 
-  describe command("mysql -u #{db_user_name} #{db_password} --host 127.0.0.1 --database forseti_security --execute \"select * from inventory_index where id = #{@inventory_id};\"") do
+  describe command("mysql -u #{db_user_name} -p#{db_password} --host 127.0.0.1 --database forseti_security --execute \"select * from inventory_index where id = #{@inventory_id};\"") do
     its('exit_status') { should eq 0 }
     its('stdout') { should match (/#{@inventory_id}/)}
   end

--- a/integration_tests/tests/forseti/controls/inventory-purge.rb
+++ b/integration_tests/tests/forseti/controls/inventory-purge.rb
@@ -15,11 +15,8 @@
 require 'securerandom'
 require 'json'
 
-db_user_name = attribute('db_user_name')
-db_password = attribute('db_password')
-if db_password.strip != ""
-  db_password = "-p#{db_password}"
-end
+db_user_name = attribute('forseti-cloudsql-user')
+db_password = attribute('forseti-cloudsql-password')
 random_string = SecureRandom.uuid.gsub!('-', '')[0..10]
 
 control "inventory-purge" do
@@ -29,7 +26,7 @@ control "inventory-purge" do
     its('exit_status') { should eq 0 }
   end
 
-  describe command("mysql -u #{db_user_name} #{db_password} --host 127.0.0.1 --database forseti_security --execute \"select count(DISTINCT gcp_inventory.inventory_index_id) from gcp_inventory join inventory_index ON inventory_index.id = gcp_inventory.inventory_index_id where inventory_index.id = #{@inventory_id};\"") do
+  describe command("mysql -u #{db_user_name} -p#{db_password} --host 127.0.0.1 --database forseti_security --execute \"select count(DISTINCT gcp_inventory.inventory_index_id) from gcp_inventory join inventory_index ON inventory_index.id = gcp_inventory.inventory_index_id where inventory_index.id = #{@inventory_id};\"") do
     its('exit_status') { should eq 0 }
     its('stdout') { should match (/1/)}
   end
@@ -38,12 +35,12 @@ control "inventory-purge" do
     its('exit_status') { should eq 0 }
   end
 
-  describe command("mysql -u #{db_user_name} #{db_password} --host 127.0.0.1 --database forseti_security --execute \"select count(DISTINCT gcp_inventory.inventory_index_id) from gcp_inventory join inventory_index ON inventory_index.id = gcp_inventory.inventory_index_id where inventory_index.id = #{@inventory_id};\"") do
+  describe command("mysql -u #{db_user_name} -p#{db_password} --host 127.0.0.1 --database forseti_security --execute \"select count(DISTINCT gcp_inventory.inventory_index_id) from gcp_inventory join inventory_index ON inventory_index.id = gcp_inventory.inventory_index_id where inventory_index.id = #{@inventory_id};\"") do
     its('exit_status') { should eq 0 }
     its('stdout') { should match (/0/)}
   end
 
-  describe command("mysql  -u #{db_user_name} #{db_password} --host 127.0.0.1 --database forseti_security --execute \"select count(*) from inventory_index;\"") do
+  describe command("mysql  -u #{db_user_name} -p#{db_password} --host 127.0.0.1 --database forseti_security --execute \"select count(*) from inventory_index;\"") do
     its('exit_status') { should eq 0 }
     its('stdout') { should match (/0/)}
   end

--- a/integration_tests/tests/forseti/controls/model-create_and_get.rb
+++ b/integration_tests/tests/forseti/controls/model-create_and_get.rb
@@ -15,11 +15,8 @@
 require 'securerandom'
 require 'json'
 
-db_user_name = attribute('db_user_name')
-db_password = attribute('db_password')
-if db_password.strip != ""
-  db_password = "-p#{db_password}"
-end
+db_user_name = attribute('forseti-cloudsql-user')
+db_password = attribute('forseti-cloudsql-password')
 random_string = SecureRandom.uuid.gsub!('-', '')[0..10]
 
 control "model-create-get" do
@@ -35,7 +32,7 @@ control "model-create-get" do
     its('stdout') { should match (/PARTIAL_SUCCESS/)}
   end
 
-  describe command("mysql -u #{db_user_name} #{db_password} --host 127.0.0.1 --database forseti_security --execute \"select state from model where name = '#{random_string}';\"") do
+  describe command("mysql -u #{db_user_name} -p#{db_password} --host 127.0.0.1 --database forseti_security --execute \"select state from model where name = '#{random_string}';\"") do
     its('exit_status') { should eq 0 }
     its('stdout') { should match (/PARTIAL_SUCCESS/)}
   end

--- a/integration_tests/tests/forseti/controls/model-delete.rb
+++ b/integration_tests/tests/forseti/controls/model-delete.rb
@@ -15,11 +15,8 @@
 require 'securerandom'
 require 'json'
 
-db_user_name = attribute('db_user_name')
-db_password = attribute('db_password')
-if db_password.strip != ""
-  db_password = "-p#{db_password}"
-end
+db_user_name = attribute('forseti-cloudsql-user')
+db_password = attribute('forseti-cloudsql-password')
 random_string = SecureRandom.uuid.gsub!('-', '')[0..10]
 
 control "model-delete" do
@@ -34,7 +31,7 @@ control "model-delete" do
     its('stdout') { should match (/#{random_string}/)}
   end
 
-  describe command("mysql -u #{db_user_name} #{db_password} --host 127.0.0.1 --database forseti_security --execute \"select count(*) from model where name = '#{random_string}';\"") do
+  describe command("mysql -u #{db_user_name} -p#{db_password} --host 127.0.0.1 --database forseti_security --execute \"select count(*) from model where name = '#{random_string}';\"") do
     its('exit_status') { should eq 0 }
     its('stdout') { should match (/1/)}
   end
@@ -44,7 +41,7 @@ control "model-delete" do
     its('stdout') { should match (/SUCCESS/)}
   end
 
-  describe command("mysql -u #{db_user_name} #{db_password} --host 127.0.0.1 --database forseti_security --execute \"select count(*) from model where name = '#{random_string}';\"") do
+  describe command("mysql -u #{db_user_name} -p#{db_password} --host 127.0.0.1 --database forseti_security --execute \"select count(*) from model where name = '#{random_string}';\"") do
     its('exit_status') { should eq 0 }
     its('stdout') { should match (/0/)}
   end

--- a/integration_tests/tests/forseti/controls/scanner-bucket_acl_scanner.rb
+++ b/integration_tests/tests/forseti/controls/scanner-bucket_acl_scanner.rb
@@ -16,11 +16,8 @@ require 'json'
 require 'securerandom'
 
 bucket_name = attribute('test-resource-bucket-scanner-bucket')
-db_user_name = attribute('db_user_name')
-db_password = attribute('db_password')
-if db_password.strip != ""
-  db_password = "-p#{db_password}"
-end
+db_user_name = attribute('forseti-cloudsql-user')
+db_password = attribute('forseti-cloudsql-password')
 project_id = attribute('project_id')
 model_name = SecureRandom.uuid.gsub!('-', '')[0..10]
 
@@ -39,7 +36,7 @@ control 'scanner-bucket-acl-scanner' do
 
   @scanner_id = /Scanner Index ID: ([0-9]*) is created/.match(scanner_run.stdout)[1]
 
-  describe command("mysql -u #{db_user_name} #{db_password} --host 127.0.0.1 --database forseti_security --execute \"SELECT COUNT(*) FROM violations V WHERE V.scanner_index_id = #{@scanner_id} AND V.violation_type = 'BUCKET_VIOLATION' AND V.resource_id = '#{bucket_name}' AND V.rule_name = 'Bucket acls rule to search for exposed buckets';\"") do
+  describe command("mysql -u #{db_user_name} -p#{db_password} --host 127.0.0.1 --database forseti_security --execute \"SELECT COUNT(*) FROM violations V WHERE V.scanner_index_id = #{@scanner_id} AND V.violation_type = 'BUCKET_VIOLATION' AND V.resource_id = '#{bucket_name}' AND V.rule_name = 'Bucket acls rule to search for exposed buckets';\"") do
     its('exit_status') { should eq 0 }
     its('stdout') { should match (/1/)}
   end

--- a/integration_tests/tests/forseti/controls/scanner-run.rb
+++ b/integration_tests/tests/forseti/controls/scanner-run.rb
@@ -14,11 +14,8 @@
 
 require 'json'
 
-db_user_name = attribute('db_user_name')
-db_password = attribute('db_password')
-if db_password.strip != ""
-  db_password = "-p#{db_password}"
-end
+db_user_name = attribute('forseti-cloudsql-user')
+db_password = attribute('forseti-cloudsql-password')
 random_string = SecureRandom.uuid.gsub!('-', '')[0..10]
 
 control "scanner-run" do
@@ -30,7 +27,7 @@ control "scanner-run" do
 
   @scanner_index_id = /Scanner Index ID: ([0-9]*) is created/.match(command("forseti scanner run").stdout)[1]
 
-  describe command("mysql -u #{db_user_name} #{db_password} --host 127.0.0.1 --database forseti_security --execute \"SELECT SI.* FROM scanner_index SI WHERE id = #{@scanner_index_id};\"") do
+  describe command("mysql -u #{db_user_name} -p#{db_password} --host 127.0.0.1 --database forseti_security --execute \"SELECT SI.* FROM scanner_index SI WHERE id = #{@scanner_index_id};\"") do
     its('exit_status') { should eq 0 }
     its('stdout') { should match (/SUCCESS/)}
   end

--- a/integration_tests/tests/forseti/inspec.yml
+++ b/integration_tests/tests/forseti/inspec.yml
@@ -14,57 +14,57 @@
 
 name: forseti_integration_testing
 attributes:
-- name: project_id
+- name: forseti-cai-storage-bucket
   required: true
   type: string
-- name: network_project
-  required: false
-  type: string
-  default: ''
-- name: org_id
-  required: true
-  type: string
-- name: suffix
-  required: true
-  type: string
-- name: db_user_name
-  required: true
-  type: string
-  value: root
-- name: db_password
-  required: true
-  type: string
-  value: ''
 - name: forseti-client-vm-name
-  required: true
-  type: string
-- name: forseti-client-vm-ip
-  required: true
-  type: string
-- name: forseti-server-vm-name
-  required: true
-  type: string
-- name: forseti-server-vm-ip
-  required: true
-  type: string
-- name: forseti-client-storage-bucket
-  required: true
-  type: string
-- name: forseti-server-storage-bucket
   required: true
   type: string
 - name: forseti-client-service-account
   required: true
   type: string
+- name: forseti-client-storage-bucket
+  required: true
+  type: string
+- name: forseti-client-vm-ip
+  required: true
+  type: string
+- name: forseti-cloudsql-password
+  required: true
+  type: string
+  value: ''
+- name: forseti-cloudsql-user
+  required: true
+  type: string
+  value: root
+- name: forseti-server-vm-name
+  required: true
+  type: string
 - name: forseti-server-service-account
   required: true
   type: string
-- name: forseti-cai-storage-bucket
+- name: forseti-server-storage-bucket
+  required: true
+  type: string
+- name: forseti-server-vm-ip
   required: true
   type: string
 - name: kms_resources_names
   required: true
   type: array
+- name: network_project
+  required: false
+  type: string
+- name: org_id
+  required: true
+  type: string
+- name: project_id
+  required: true
+  type: string
+  default: ''
+- name: suffix
+  required: true
+  type: string
 - name: test-resource-bucket-scanner-bucket
   required: true
   type: string


### PR DESCRIPTION
In order for the tests to connect to the database going forward, they will need to supply the username and password. This change updates the fixture outputs to provide these values to Inspec. Updated the tests to use these outputs as well.

Previously the tests were mostly all failing on the master branch, now most tests are passing again. Overall some are still failing. Test results:

forseti-client
```
Profile Summary: 5 successful controls, 1 control failure, 0 controls skipped
Test Summary: 156 successful, 2 failures, 0 skipped
```

forseti-server
```
Profile Summary: 7 successful controls, 4 control failures, 0 controls skipped
Test Summary: 79 successful, 4 failures, 0 skipped
```

Resolves #3524 