### PR TITLE
Fix bug where rules are found to not exist if a GCS rules path is used.

### DIFF
--- a/google/cloud/forseti/scanner/scanner_builder.py
+++ b/google/cloud/forseti/scanner/scanner_builder.py
@@ -19,7 +19,7 @@ import importlib
 import inspect
 import os
 
-from google.cloud.forseti.common.util import logger
+from google.cloud.forseti.common.util import file_loader, logger
 from google.cloud.forseti.scanner import scanner_requirements_map
 
 LOGGER = logger.get_logger(__name__)
@@ -122,11 +122,15 @@ class ScannerBuilder(object):
                 scanner_path = inspect.getfile(scanner_class)
                 rules_directory = scanner_path.split('/google/cloud/forseti')[0]
                 rules_directory += '/rules'
-            rules_path = '{}/{}'.format(rules_directory, rules_filename)
+            rules_path = os.path.join(rules_directory, rules_filename)
 
-            if not os.path.isfile(rules_path):
+            if not file_loader.isfile(rules_path):
                 LOGGER.error(f'Rules file for Scanner {scanner_name} does not '
                              f'exist. Rules path: {rules_path}')
+                return None
+            if not file_loader.access(rules_path):
+                LOGGER.error(f'Rules file for Scanner {scanner_name} cannot '
+                             f'be accessed. Rules path: {rules_path}')
                 return None
 
         LOGGER.info('Initializing the rules engine:\nUsing rules: %s',


### PR DESCRIPTION
A change was made previously this release to move the sample rules out of the /rules directory, and to verify the rule file exists before creating the scanner. This logic didn't take into account the option users have to use GCS for storing their rules. This has been updated to use the file_loader class which supports GCS + local files.