### PR TITLE
Added guard-jekyll-plus plugin for smarter Jekyll builds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,4 +17,5 @@ group :jekyll_plugins do
   gem 'jekyll-redirect-from'
   gem 'jekyll-responsive-image'
   gem 'jekyll-include-cache'
+  gem 'guard-jekyll-plus'
 end

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,8 @@
+# The Guardfile
+# Taken directly from https://github.com/imathis/guard-jekyll-plus
+
+ignore /^_site/ # NOTE: this can interfere with Guard::LiveReload
+
+guard "jekyll-plus", :serve => true do
+  watch /.*/
+end

--- a/_config.yml
+++ b/_config.yml
@@ -30,7 +30,8 @@ exclude: ["Gemfile",
           ".sass-cache/",
           ".ruby-version",
           "_sass",
-          "third_party/sphinx-doc/"]
+          "third_party/sphinx-doc/",
+          "Guardfile"]
 exclude_from_watch: ["_docs/latest/",
                      "_data/doc_versions.yml",
                      "_data/doc_version_index.yml",


### PR DESCRIPTION
Below are the features of Guard Jekyll Plus plugin:

1. Changing static files won't trigger a jekyll build
2. Batched processing
3. Reads options from your YAML config file(s)
4. Supports multiple config files
5. Serve with Jekyll or Rack
6. Clear and colorized output.