### PR TITLE
Update forseti terraform module version used in sample main.tf

### DIFF
--- a/_docs/_latest/setup/install.md
+++ b/_docs/_latest/setup/install.md
@@ -79,7 +79,7 @@ Create a file named `main.tf` in an empty directory and copy the contents below 
 ```hcl
 module "forseti" {
   source  = "terraform-google-modules/forseti/google"
-  version = "~> 5.0.0"
+  version = "~> 5.2.0"
 
   gsuite_admin_email = "superadmin@yourdomain.com"
   domain             = "yourdomain.com"

--- a/_docs/v2.24/setup/install.md
+++ b/_docs/v2.24/setup/install.md
@@ -77,7 +77,7 @@ Create a file named `main.tf` in an empty directory and copy the contents below 
 ```hcl
 module "forseti" {
   source  = "terraform-google-modules/forseti/google"
-  version = "~> 5.0.0"
+  version = "~> 5.1.0"
 
   gsuite_admin_email = "superadmin@yourdomain.com"
   domain             = "yourdomain.com"

--- a/_docs/v2.25/setup/install.md
+++ b/_docs/v2.25/setup/install.md
@@ -79,7 +79,7 @@ Create a file named `main.tf` in an empty directory and copy the contents below 
 ```hcl
 module "forseti" {
   source  = "terraform-google-modules/forseti/google"
-  version = "~> 5.0.0"
+  version = "~> 5.2.0"
 
   gsuite_admin_email = "superadmin@yourdomain.com"
   domain             = "yourdomain.com"


### PR DESCRIPTION
Update the sample main.tf configurations shown on the website. The version displayed uses 5.0.0 of the module, which has known compatibilities issues. I am merging this directly to forsetisecurity.org because there have been additional PRs merged into forsetisecurity.org-dev after the release changes have gone through.