### PR TITLE
Add test for Forseti Enforcer

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -54,6 +54,7 @@ suites:
         - name: forseti-server
           backend: ssh
           controls:
+            - enforcer-remediates-firewall-rule
             - inventory-create
             - inventory-delete
             - inventory-get-list

--- a/integration_tests/fixtures/forseti/main.tf
+++ b/integration_tests/fixtures/forseti/main.tf
@@ -130,6 +130,15 @@ resource "null_resource" "install-mysql-client" {
 }
 
 #-------------------------#
+# Forseti IAM
+#-------------------------#
+module "forseti_iam" {
+  source                         = "./modules/forseti_iam"
+  forseti_server_service_account = module.forseti.forseti-server-service-account
+  project_id                     = var.project_id
+}
+
+#-------------------------#
 # Forseti Server Rules
 #-------------------------#
 module "forseti_server_rules" {

--- a/integration_tests/fixtures/forseti/modules/forseti_iam/main.tf
+++ b/integration_tests/fixtures/forseti/modules/forseti_iam/main.tf
@@ -18,6 +18,7 @@ resource "google_project_iam_custom_role" "forseti-enforcer-admin" {
   title       = "Forseti Enforcer Admin"
   description = "Access to delete firewall rules and update policy."
   permissions = [
+    "compute.firewalls.create",
     "compute.firewalls.delete",
     "compute.networks.updatePolicy",
   ]

--- a/integration_tests/fixtures/forseti/modules/forseti_iam/main.tf
+++ b/integration_tests/fixtures/forseti/modules/forseti_iam/main.tf
@@ -1,0 +1,32 @@
+/**
+* Copyright 2019 Google LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+resource "google_project_iam_custom_role" "forseti-enforcer-admin" {
+  role_id     = "forsetiEnforcerAdmin"
+  title       = "Forseti Enforcer Admin"
+  description = "Access to delete firewall rules and update policy."
+  permissions = [
+    "compute.firewalls.delete",
+    "compute.networks.updatePolicy",
+  ]
+  project     = var.project_id
+}
+
+resource "google_project_iam_member" "forseti-server-enforcer-admin-role" {
+  role    = google_project_iam_custom_role.forseti-enforcer-admin.id
+  project = var.project_id
+  member  = "serviceAccount:${var.forseti_server_service_account}"
+}
+

--- a/integration_tests/fixtures/forseti/modules/forseti_iam/variables.tf
+++ b/integration_tests/fixtures/forseti/modules/forseti_iam/variables.tf
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "forseti_server_service_account" {
+  description = "The email of the Forseti Server service account"
+}
+
+variable "project_id" {
+  description = "The ID of an existing Google project where Forseti will be installed"
+}

--- a/integration_tests/fixtures/forseti/modules/forseti_iam/versions.tf
+++ b/integration_tests/fixtures/forseti/modules/forseti_iam/versions.tf
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+terraform {
+  required_version = ">= 0.12"
+  required_providers {
+    google = "2.18.1"
+  }
+}

--- a/integration_tests/fixtures/forseti/modules/test_resources/main.tf
+++ b/integration_tests/fixtures/forseti/modules/test_resources/main.tf
@@ -21,6 +21,21 @@ resource "random_pet" "random_name_generator" {
 }
 
 #-------------------------#
+# enforcer-remediates_non_compliant_rule.rb: Create a firewall rule to test it gets removed
+#-------------------------#
+resource "google_compute_firewall" "enforcer_allow_all_icmp_rule" {
+  name                    = "forseti-server-allow-icmp-${random_id.random_test_id.hex}"
+  project                 = var.project_id
+  network                 = "default"
+  priority                = "100"
+  source_ranges           = ["10.0.0.0/32"]
+
+  allow {
+    protocol = "icmp"
+  }
+}
+
+#-------------------------#
 # inventory-create.rb: Create KMS resources for inventory testing
 #-------------------------#
 resource "google_kms_key_ring" "test-keyring" {

--- a/integration_tests/fixtures/forseti/modules/test_resources/outputs.tf
+++ b/integration_tests/fixtures/forseti/modules/test_resources/outputs.tf
@@ -19,6 +19,11 @@ output "bucket_acl_scanner_bucket_name" {
   value = google_storage_bucket.bucket_acl_scanner.name
 }
 
+output "enforcer_allow_all_icmp_rule_name" {
+  description = "Firewall rule name created for the Firewall Enforcer test"
+  value = google_compute_firewall.enforcer_allow_all_icmp_rule.name
+}
+
 output "kms_resources_names" {
   description = "KMS resources for Inventory tests"
   value       = [

--- a/integration_tests/fixtures/forseti/outputs.tf
+++ b/integration_tests/fixtures/forseti/outputs.tf
@@ -100,6 +100,11 @@ output "bucket_acl_scanner_bucket_name" {
   value = module.test_resources.bucket_acl_scanner_bucket_name
 }
 
+output "enforcer_allow_all_icmp_rule_name" {
+  description = "Firewall rule name created for the Firewall Enforcer test"
+  value = module.test_resources.enforcer_allow_all_icmp_rule_name
+}
+
 output "random_test_id" {
   description = "Random test id generated every time the tests are run"
   value       = module.test_resources.random_test_id

--- a/integration_tests/tests/forseti/controls/enforcer-remediates_non_compliant_rule.rb
+++ b/integration_tests/tests/forseti/controls/enforcer-remediates_non_compliant_rule.rb
@@ -1,0 +1,74 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'json'
+require 'securerandom'
+
+firewall_rule_name = attribute('enforcer_allow_all_icmp_rule_name')
+project_id = attribute('project_id')
+
+control "enforcer-remediates-firewall-rule" do
+  # Get the latest firewall rules
+  fw_rules_cmd = command("sudo gcloud compute firewall-rules list --format=json")
+  describe fw_rules_cmd do
+    its('exit_status') { should eq 0 }
+  end
+
+  fw_rules = JSON.parse(fw_rules_cmd.stdout)
+  filtered_rules = []
+  fw_rules.each { |rule|
+    if  /#{firewall_rule_name}/.match(rule["name"])
+      # mark all rules generated for this test for deletion
+      next
+    end
+
+    # Remove all the attributes enforcer does not like
+    rule.delete("kind")
+    rule.delete("selfLink")
+    rule.delete("id")
+    rule.delete("creationTimestamp")
+    rule.delete("targetServiceAccounts")
+    rule.delete("sourceServiceAccounts")
+    filtered_rules.push(rule)
+  }
+
+  # Write the current firewall rules to a json file
+  describe command("echo '#{JSON.dump(filtered_rules)}' > /tmp/current_fw_rule.json") do
+    its('exit_status') { should eq 0 }
+  end
+
+  # Make sure the file exist
+  describe file('/tmp/current_fw_rule.json') do
+    it { should exist }
+  end
+
+  # Act
+  describe command("forseti_enforcer --enforce_project #{project_id} --policy_file /tmp/current_fw_rule.json") do
+    its('exit_status') { should eq 0 }
+  end
+
+  # Assert
+  describe command("sudo gcloud compute firewall-rules list --format=json") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not match(/#{Regexp.quote(firewall_rule_name)}/) }
+  end
+
+  # Cleanup
+  describe command("rm /tmp/current_fw_rule.json") do
+    its('exit_status') { should eq 0 }
+  end
+  describe file('/tmp/current_fw_rule.json') do
+    it { should_not exist }
+  end
+end

--- a/integration_tests/tests/forseti/inspec.yml
+++ b/integration_tests/tests/forseti/inspec.yml
@@ -17,6 +17,9 @@ attributes:
 - name: bucket_acl_scanner_bucket_name
   required: true
   type: string
+- name: enforcer_allow_all_icmp_rule_name
+  required: true
+  type: string
 - name: forseti-cai-storage-bucket
   required: true
   type: string


### PR DESCRIPTION
Based off previous work from branch feature/issues-3363. Updated test to setup a custom role for the forseti server service account to be able to delete firewall rules.

Resolves #3363