### PR TITLE
Add test for CV Scanner to use policy from GCS.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -65,6 +65,7 @@ suites:
             - model-delete
             - notifier-temp-file-deletion
             - scanner-bucket-acl-scanner
+            - scanner-config_validator_gcs_policy
             - scanner-enabled-apis-scanner
             - scanner-enable-audit-logging-scanner
             - scanner-run

--- a/integration_tests/fixtures/forseti/main.tf
+++ b/integration_tests/fixtures/forseti/main.tf
@@ -53,10 +53,11 @@ module "bastion" {
 module "forseti" {
   source = "git::github.com/forseti-security/terraform-google-forseti"
 
-  project_id      = var.project_id
-  org_id          = var.org_id
-  domain          = var.domain
-  forseti_version = var.forseti_version
+  project_id               = var.project_id
+  org_id                   = var.org_id
+  domain                   = var.domain
+  forseti_version          = var.forseti_version
+  config_validator_enabled = var.config_validator_enabled
 
   client_instance_metadata = {
     sshKeys = "ubuntu:${tls_private_key.main.public_key_openssh}"
@@ -144,13 +145,21 @@ module "forseti_iam" {
 }
 
 #-------------------------#
-# Forseti Server Rules
+# Forseti Rules
 #-------------------------#
 module "forseti_server_rules" {
   source                        = "./modules/rules"
   domain                        = var.domain
   forseti_server_storage_bucket = module.forseti.forseti-server-storage-bucket
   org_id                        = var.org_id
+}
+
+#-------------------------#
+# Policy Library GCS
+#-------------------------#
+module "policy_library" {
+  source                        = "./modules/policy_library"
+  forseti_server_storage_bucket = module.forseti.forseti-server-storage-bucket
 }
 
 #-------------------------#

--- a/integration_tests/fixtures/forseti/modules/policy_library/main.tf
+++ b/integration_tests/fixtures/forseti/modules/policy_library/main.tf
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  files = [
+    "constraints/cloudsql_location.yaml",
+    "constraints/compute_zone.yaml",
+  ]
+}
+
+data "template_file" "constraints" {
+  count = length(local.files)
+  template = file(
+    "${path.module}/templates/${element(local.files, count.index)}",
+  )
+}
+
+resource "google_storage_bucket_object" "main" {
+  count   = length(local.files)
+  name    = "policy-library/policies/${element(local.files, count.index)}"
+  content = element(data.template_file.constraints.*.rendered, count.index)
+  bucket  = var.forseti_server_storage_bucket
+
+  lifecycle {
+    ignore_changes = [
+      content,
+      detect_md5hash,
+    ]
+  }
+}

--- a/integration_tests/fixtures/forseti/modules/policy_library/templates/constraints/cloudsql_location.yaml
+++ b/integration_tests/fixtures/forseti/modules/policy_library/templates/constraints/cloudsql_location.yaml
@@ -1,0 +1,27 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPSQLLocationConstraintV1
+metadata:
+  name: sql_location_denylist
+spec:
+  severity: high
+  match:
+    target: ["organization/*"]
+  parameters:
+    mode: "denylist"
+    locations:
+    - us-central1
+    exemptions: []

--- a/integration_tests/fixtures/forseti/modules/policy_library/templates/constraints/compute_zone.yaml
+++ b/integration_tests/fixtures/forseti/modules/policy_library/templates/constraints/compute_zone.yaml
@@ -1,0 +1,25 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: GCPComputeZoneConstraintV1
+metadata:
+  name: compute_zone_denylist
+spec:
+  severity: high
+  parameters:
+    mode: "denylist"
+    zones:
+      - us-central1-c
+    exemptions: []

--- a/integration_tests/fixtures/forseti/modules/policy_library/variables.tf
+++ b/integration_tests/fixtures/forseti/modules/policy_library/variables.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "forseti_server_storage_bucket" {
+  description = "The Forseti Server GCS bucket name"
+}

--- a/integration_tests/fixtures/forseti/variables.tf
+++ b/integration_tests/fixtures/forseti/variables.tf
@@ -18,8 +18,18 @@ variable "billing_account" {
   description = "GCP Organization billing account details"
 }
 
+variable "config_validator_enabled" {
+  description = "Config Validator scanner enabled"
+  default     = true
+}
+
 variable "domain" {
   description = "GCP Organization domain details that will be used for integration tests"
+}
+
+variable "forseti_version" {
+  description = "The version of Forseti to deploy"
+  default = "master"
 }
 
 variable "gsuite_admin_email" {
@@ -32,9 +42,4 @@ variable "org_id" {
 
 variable "project_id" {
   description = "The ID of an existing Google project where Forseti will be installed"
-}
-
-variable "forseti_version" {
-  description = "The version of Forseti to deploy"
-  default = "master"
 }

--- a/integration_tests/tests/forseti/controls/scanner-config_validator_gcs_policy.rb
+++ b/integration_tests/tests/forseti/controls/scanner-config_validator_gcs_policy.rb
@@ -1,0 +1,73 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'json'
+require 'securerandom'
+
+db_password = attribute('forseti-cloudsql-password')
+db_user_name = attribute('forseti-cloudsql-user')
+forseti_server_storage_bucket = attribute('forseti-server-storage-bucket')
+forseti_server_vm_name = attribute('forseti-server-vm-name')
+forseti_suffix = attribute('suffix')
+forseti_cloudsql_instance_name = "forseti-server-db-#{forseti_suffix}"
+model_name = SecureRandom.uuid.gsub!('-', '')[0..10]
+policy_library_path = '/home/ubuntu/policy-library/policy-library'
+
+control "scanner-config_validator_gcs_policy" do
+  # Arrange
+  @inventory_id = /\"id\"\: \"([0-9]*)\"/.match(command("forseti inventory create --import_as #{model_name}").stdout)[1]
+  describe command("forseti model use #{model_name}") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not match /Error communicating to the Forseti server./ }
+  end
+
+  # Clone Policy Library repo
+  describe command("sudo rm -rf #{policy_library_path}") do
+    its('exit_status') { should eq 0 }
+  end
+
+  describe command("sudo git clone https://github.com/forseti-security/policy-library.git --branch master --depth 1 #{policy_library_path}") do
+    its('exit_status') { should eq 0 }
+  end
+
+  # Copy the constraints from GCS
+  describe command("sudo gsutil cp -r gs://#{forseti_server_storage_bucket}/policy-library/policies #{policy_library_path}") do
+    its('exit_status') { should eq 0 }
+  end
+
+  # Restart Config Validator
+  describe command("sudo systemctl restart config-validator") do
+    its('exit_status') { should eq 0 }
+  end
+
+  # Act
+  describe command("forseti scanner run") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should match (/Running ConfigValidatorScanner.../) }
+    its('stdout') { should match (/Scan completed/) }
+    its('stdout') { should match (/Scanner Index ID: .*([0-9]*) is created/) }
+  end
+
+  # Assert violations exist for Cloud SQL Location policy
+  describe command("mysql -u #{db_user_name} -p#{db_password} --host 127.0.0.1 --database forseti_security --execute \"SELECT COUNT(*) FROM violations V JOIN forseti_security.scanner_index SI ON SI.id = V.scanner_index_id WHERE SI.inventory_index_id = #{@inventory_id} AND V.resource_id = '#{forseti_cloudsql_instance_name}' AND V.violation_type = 'CONFIG_VALIDATOR_VIOLATION' AND V.rule_name = 'sql_location_denylist';\"") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should match (/1/) }
+  end
+
+  # Assert violations exist for Compute Zone policy
+  describe command("mysql -u #{db_user_name} -p#{db_password} --host 127.0.0.1 --database forseti_security --execute \"SELECT COUNT(*) FROM violations V JOIN forseti_security.scanner_index SI ON SI.id = V.scanner_index_id WHERE SI.inventory_index_id = #{@inventory_id} AND V.resource_id = '#{forseti_server_vm_name}' AND V.resource_type = 'compute.googleapis.com/Instance' AND V.violation_type = 'CONFIG_VALIDATOR_VIOLATION' AND V.rule_name = 'compute_zone_denylist';\"") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should match (/1/) }
+  end
+end

--- a/integration_tests/tests/forseti/controls/scanner-config_validator_gcs_policy.rb
+++ b/integration_tests/tests/forseti/controls/scanner-config_validator_gcs_policy.rb
@@ -56,7 +56,7 @@ control "scanner-config_validator_gcs_policy" do
     its('exit_status') { should eq 0 }
     its('stdout') { should match (/Running ConfigValidatorScanner.../) }
     its('stdout') { should match (/Scan completed/) }
-    its('stdout') { should match (/Scanner Index ID: .*([0-9]*) is created/) }
+    its('stdout') { should match (/Scanner Index ID: (.*[0-9]*) is created/) }
   end
 
   # Assert violations exist for Cloud SQL Location policy


### PR DESCRIPTION
This test will enable Config Validator, pull policy from GCS, and confirm that the CV constraints produce violations. This test will fail because of a known issue with Config Validator on the master branch. The test works if the CV issue is fixed locally:

```
✔  scanner-config_validator_gcs_policy: Command: `forseti model use 01c4f26e53f`
     ✔  Command: `forseti model use 01c4f26e53f` exit_status should eq 0
     ✔  Command: `forseti model use 01c4f26e53f` stdout should not match /Error communicating to the Forseti server./
     ✔  Command: `sudo rm -rf /home/ubuntu/policy-library/policy-library` exit_status should eq 0
     ✔  Command: `sudo git clone https://github.com/forseti-security/policy-library.git --branch master --depth 1 /home/ubuntu/policy-library/policy-library` exit_status should eq 0
     ✔  Command: `sudo gsutil cp -r gs://forseti-server-6451f879/policy-library/policies /home/ubuntu/policy-library/policy-library` exit_status should eq 0
     ✔  Command: `sudo systemctl restart config-validator` exit_status should eq 0
     ✔  Command: `forseti scanner run` exit_status should eq 0
     ✔  Command: `forseti scanner run` stdout should match /Running ConfigValidatorScanner.../
     ✔  Command: `forseti scanner run` stdout should match /Scan completed/
     ✔  Command: `forseti scanner run` stdout should match /Scanner Index ID: .*([0-9]*) is created/
     ✔  Command: `mysql -u forseti_security_user -pzBZVzQ@TIfpVDggs --host 127.0.0.1 --database forseti_security --execute "SELECT COUNT(*) FROM violations V JOIN forseti_security.scanner_index SI ON SI.id = V.scanner_index_id WHERE SI.inventory_index_id = 1576859514624497 AND V.resource_id = 'forseti-server-db-6451f879' AND V.violation_type = 'CONFIG_VALIDATOR_VIOLATION' AND V.rule_name = 'sql_location_denylist';"` exit_status should eq 0
     ✔  Command: `mysql -u forseti_security_user -pzBZVzQ@TIfpVDggs --host 127.0.0.1 --database forseti_security --execute "SELECT COUNT(*) FROM violations V JOIN forseti_security.scanner_index SI ON SI.id = V.scanner_index_id WHERE SI.inventory_index_id = 1576859514624497 AND V.resource_id = 'forseti-server-db-6451f879' AND V.violation_type = 'CONFIG_VALIDATOR_VIOLATION' AND V.rule_name = 'sql_location_denylist';"` stdout should match /1/
     ✔  Command: `mysql -u forseti_security_user -pzBZVzQ@TIfpVDggs --host 127.0.0.1 --database forseti_security --execute "SELECT COUNT(*) FROM violations V JOIN forseti_security.scanner_index SI ON SI.id = V.scanner_index_id WHERE SI.inventory_index_id = 1576859514624497 AND V.resource_id = 'forseti-server-vm-6451f879' AND V.resource_type = 'compute.googleapis.com/Instance' AND V.violation_type = 'CONFIG_VALIDATOR_VIOLATION' AND V.rule_name = 'compute_zone_denylist';"` exit_status should eq 0
     ✔  Command: `mysql -u forseti_security_user -pzBZVzQ@TIfpVDggs --host 127.0.0.1 --database forseti_security --execute "SELECT COUNT(*) FROM violations V JOIN forseti_security.scanner_index SI ON SI.id = V.scanner_index_id WHERE SI.inventory_index_id = 1576859514624497 AND V.resource_id = 'forseti-server-vm-6451f879' AND V.resource_type = 'compute.googleapis.com/Instance' AND V.violation_type = 'CONFIG_VALIDATOR_VIOLATION' AND V.rule_name = 'compute_zone_denylist';"` stdout should match /1/
```