### PR TITLE
Add test for firewall scanner

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -70,6 +70,7 @@ suites:
             - scanner-config-validator-gcs-policy
             - scanner-enabled-apis-scanner
             - scanner-enable-audit-logging-scanner
+            - scanner-firewall-scanner
             - scanner-run
           hosts_output: forseti-server-vm-ip
           user: ubuntu

--- a/integration_tests/fixtures/forseti/modules/test_resources/main.tf
+++ b/integration_tests/fixtures/forseti/modules/test_resources/main.tf
@@ -72,3 +72,22 @@ resource "google_storage_bucket_access_control" "bucket_acl_scanner_all_users_ac
     google_storage_bucket_access_control.bucket_acl_scanner_all_auth_acl
   ]
 }
+
+#-------------------------#
+# scanner-firewall_scanner.rb: Create a disabled firewall rule allowing all ingress
+#-------------------------#
+resource "google_compute_firewall" "firewall_allow_all_ingress" {
+  name                    = "forseti-allow-all-ingress-${var.random_test_id}"
+  description             = "Forseti test firewall rule for firewall scanner"
+  disabled                = true
+  network                 = "default"
+  priority                = "1000"
+  project                 = var.project_id
+  source_ranges           = ["10.0.0.0/32"]
+  source_tags             = ["forseti-test-tag"]
+  target_tags             = ["forseti-test-tag"]
+
+  allow {
+    protocol = "all"
+  }
+}

--- a/integration_tests/fixtures/forseti/modules/test_resources/outputs.tf
+++ b/integration_tests/fixtures/forseti/modules/test_resources/outputs.tf
@@ -24,6 +24,11 @@ output "enforcer_allow_all_icmp_rule_name" {
   value = google_compute_firewall.enforcer_allow_all_icmp_rule.name
 }
 
+output "firewall-allow-all-ingress-name" {
+  description = "Firewall rule name created for the firewall scanner test"
+  value       = google_compute_firewall.firewall_allow_all_ingress.name
+}
+
 output "inventory-cai-eu-bucket-name" {
   description = "Bucket name of EU bucket create for the the Inventory CAI Enabled vs Disabled test"
   value = google_storage_bucket.inventory_cai_eu.name

--- a/integration_tests/fixtures/forseti/outputs.tf
+++ b/integration_tests/fixtures/forseti/outputs.tf
@@ -105,6 +105,11 @@ output "enforcer_allow_all_icmp_rule_name" {
   value       = module.test_resources.enforcer_allow_all_icmp_rule_name
 }
 
+output "firewall-allow-all-ingress-name" {
+  description = "Firewall rule name created for the firewall scanner test"
+  value       = module.test_resources.firewall-allow-all-ingress-name
+}
+
 output "inventory-performance-cai-dump-paths" {
   description = "GCS paths of the CAI dump files to be used for the inventory performance test"
   value       = var.inventory_performance_cai_dump_paths

--- a/integration_tests/tests/forseti/controls/scanner-firewall_scanner.rb
+++ b/integration_tests/tests/forseti/controls/scanner-firewall_scanner.rb
@@ -1,0 +1,41 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'json'
+require 'securerandom'
+
+db_password = attribute('forseti-cloudsql-password')
+db_user_name = attribute('forseti-cloudsql-user')
+firewall_name = attribute('firewall-allow-all-ingress-name')
+model_name = SecureRandom.uuid.gsub!('-', '')[0..10]
+
+control 'scanner-firewall-scanner' do
+  # Arrange
+  @inventory_id = /\"id\"\: \"([0-9]*)\"/.match(command("forseti inventory create --import_as #{model_name}").stdout)[1]
+  describe command("forseti model use #{model_name}") do
+    its('exit_status') { should eq 0 }
+  end
+
+  # Act
+  describe command("forseti scanner run") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should match(/Scanner Index ID: (.*[0-9].*) is created/) }
+  end
+
+  # Assert Firewall violation found
+  describe command("mysql -u #{db_user_name} -p#{db_password} --host 127.0.0.1 --execute \"SELECT COUNT(*) FROM forseti_security.violations V JOIN forseti_security.scanner_index SI ON SI.id = V.scanner_index_id WHERE SI.inventory_index_id = #{@inventory_id} AND V.violation_type = 'FIREWALL_BLACKLIST_VIOLATION' AND V.resource_name = '#{firewall_name}' AND V.rule_name = 'prevent_allow_all_ingress';\"") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should match(/1/) }
+  end
+end

--- a/integration_tests/tests/forseti/inspec.yml
+++ b/integration_tests/tests/forseti/inspec.yml
@@ -23,6 +23,9 @@ attributes:
 - name: forseti-cai-storage-bucket
   required: true
   type: string
+- name: firewall-allow-all-ingress-name
+  required: true
+  type: string
 - name: forseti-client-service-account
   required: true
   type: string


### PR DESCRIPTION
Add test for the firewall scanner. This will create a disabled firewall rule allowing all ingress and verify the scanner creates a violation.

Resolves #3539