### PR TITLE
Improve CV logging from Forseti

### DIFF
--- a/google/cloud/forseti/scanner/scanners/config_validator_util/errors.py
+++ b/google/cloud/forseti/scanner/scanners/config_validator_util/errors.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The Forseti Security Authors. All rights reserved.
+# Copyright 2020 The Forseti Security Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,16 +20,21 @@ class ConfigValidatorAddDataError(Exception):
     pass
 
 
-class ConfigValidatorServerUnavailableError(Exception):
-    """ConfigValidator Server Unavailable Error."""
-    pass
-
-
 class ConfigValidatorAuditError(Exception):
     """ConfigValidator Audit Error."""
     pass
 
 
+class ConfigValidatorPolicyLibraryError(Exception):
+    """ConfigValidator Policy Library Error."""
+    pass
+
+
 class ConfigValidatorResetError(Exception):
     """ConfigValidator Reset Error."""
+    pass
+
+
+class ConfigValidatorServerUnavailableError(Exception):
+    """ConfigValidator Server Unavailable Error."""
     pass

--- a/google/cloud/forseti/scanner/scanners/config_validator_util/validator_client.py
+++ b/google/cloud/forseti/scanner/scanners/config_validator_util/validator_client.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The Forseti Security Authors. All rights reserved.
+# Copyright 2020 The Forseti Security Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Config Validator Validator Client."""
+"""Config Validator Client."""
 
 
 from builtins import object
@@ -75,12 +75,11 @@ class ValidatorClient(object):
         except grpc.RpcError as e:
             # pylint: disable=no-member
             if e.code() == grpc.StatusCode.UNAVAILABLE:
-                raise errors.ConfigValidatorServerUnavailableError(
-                    e.message)
+                raise errors.ConfigValidatorServerUnavailableError(e)
             else:
                 LOGGER.exception('Failed to add data: %s', assets[0])
-                # LOGGER.exception('ConfigValidatorAddDataError: %s', e.message)
-                # raise errors.ConfigValidatorAddDataError(e.message)
+                # LOGGER.exception('ConfigValidatorAddDataError: %s', e)
+                # raise errors.ConfigValidatorAddDataError(e)
                 return
 
     def add_data_in_bulk(self, assets):
@@ -143,11 +142,10 @@ class ValidatorClient(object):
         except grpc.RpcError as e:
             # pylint: disable=no-member
             if e.code() == grpc.StatusCode.UNAVAILABLE:
-                raise errors.ConfigValidatorServerUnavailableError(
-                    e.message)
+                raise errors.ConfigValidatorServerUnavailableError(e)
             else:
-                LOGGER.exception('ConfigValidatorAuditError: %s', e.message)
-                raise errors.ConfigValidatorAuditError(e.message)
+                LOGGER.exception('ConfigValidatorAuditError: %s', e)
+                raise errors.ConfigValidatorAuditError(e)
 
     @retry(retry_on_exception=retryable_exceptions.is_retryable_exception_cv,
            wait_exponential_multiplier=10, wait_exponential_max=100,
@@ -179,11 +177,10 @@ class ValidatorClient(object):
         except grpc.RpcError as e:
             # pylint: disable=no-member
             if e.code() == grpc.StatusCode.UNAVAILABLE:
-                raise errors.ConfigValidatorServerUnavailableError(
-                    e.message)
+                raise errors.ConfigValidatorServerUnavailableError(e)
             else:
-                LOGGER.exception('ConfigValidatorAuditError: %s', e.message)
-                raise errors.ConfigValidatorAuditError(e.message)
+                LOGGER.exception('ConfigValidatorAuditError: %s', e)
+                raise errors.ConfigValidatorAuditError(e)
 
     @retry(retry_on_exception=retryable_exceptions.is_retryable_exception_cv,
            wait_exponential_multiplier=10, wait_exponential_max=100,
@@ -200,11 +197,10 @@ class ValidatorClient(object):
         except grpc.RpcError as e:
             # pylint: disable=no-member
             if e.code() == grpc.StatusCode.UNAVAILABLE:
-                raise errors.ConfigValidatorServerUnavailableError(
-                    e.message)
+                raise errors.ConfigValidatorServerUnavailableError(e)
             else:
-                LOGGER.exception('ConfigValidatorResetError: %s', e.message)
-                raise errors.ConfigValidatorResetError(e.message)
+                LOGGER.exception('ConfigValidatorResetError: %s', e)
+                raise errors.ConfigValidatorResetError(e)
 
 
 class BufferedCVDataSender(object):

--- a/install/gcp/scripts/initialize_forseti_services.sh
+++ b/install/gcp/scripts/initialize_forseti_services.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2017 The Forseti Security Authors. All rights reserved.
+# Copyright 2020 The Forseti Security Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -85,6 +85,7 @@ User=ubuntu
 Restart=always
 RestartSec=3
 ExecStart=$FORSETI_COMMAND
+Environment="POLICY_LIBRARY_HOME=${POLICY_LIBRARY_HOME}"
 [Install]
 WantedBy=multi-user.target
 EOF

--- a/install/gcp/scripts/run_forseti.sh
+++ b/install/gcp/scripts/run_forseti.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2017 The Forseti Security Authors. All rights reserved.
+# Copyright 2020 The Forseti Security Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/scanner/scanners/config_validator_scanner_test.py
+++ b/tests/scanner/scanners/config_validator_scanner_test.py
@@ -1,0 +1,92 @@
+# Copyright 2020 The Forseti Security Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest.mock as mock
+from unittest.mock import patch
+from tests.unittest_utils import ForsetiTestCase
+from google.cloud.forseti.scanner.scanners.config_validator_scanner import (
+    ConfigValidatorScanner)
+from google.cloud.forseti.scanner.scanners.config_validator_util import (
+    errors)
+
+
+class ConfigValidatorScannerTest(ForsetiTestCase):
+    """Tests for the Config Validator Scanner."""
+
+    def setUp(self):
+        self.scanner = ConfigValidatorScanner({},
+                                              {},
+                                              mock.MagicMock(),
+                                              'ScannerBuilderTestModel',
+                                              '20201237T121212Z',
+                                              '')
+
+    @patch('os.listdir')
+    @patch('os.path.isdir')
+    def test_verify_policy_library_empty_constraints_raises_exception(self,
+                                                                      mock_isdir,
+                                                                      mock_listdir):
+        mock_isdir.side_effect = [True, True, True]
+        mock_listdir.side_effect = [[], ['file1']]
+        self.assertRaises(errors.ConfigValidatorPolicyLibraryError, self.scanner.verify_policy_library)
+        self.assertEqual(mock_listdir.call_count, 1)
+
+    @patch('os.listdir')
+    @patch('os.path.isdir')
+    def test_verify_policy_library_empty_lib_raises_exception(self,
+                                                              mock_isdir,
+                                                              mock_listdir):
+        mock_isdir.side_effect = [True, True, True]
+        mock_listdir.side_effect = [['file1'], []]
+        self.assertRaises(errors.ConfigValidatorPolicyLibraryError, self.scanner.verify_policy_library)
+        self.assertEqual(mock_listdir.call_count, 2)
+
+    @patch('os.listdir')
+    @patch('os.path.isdir')
+    def test_verify_policy_library_missing_constraints_raises_exception(self,
+                                                                        mock_isdir,
+                                                                        mock_listdir):
+        mock_isdir.side_effect = [True, False, True]
+        mock_listdir.side_effect = [['file1'], ['file1']]
+        self.assertRaises(errors.ConfigValidatorPolicyLibraryError, self.scanner.verify_policy_library)
+        self.assertEqual(mock_isdir.call_count, 2)
+
+    @patch('os.listdir')
+    @patch('os.path.isdir')
+    def test_verify_policy_library_missing_lib_raises_exception(self,
+                                                                mock_isdir,
+                                                                mock_listdir):
+        mock_isdir.side_effect = [True, True, False]
+        mock_listdir.side_effect = [['file1'], ['file1']]
+        self.assertRaises(errors.ConfigValidatorPolicyLibraryError, self.scanner.verify_policy_library)
+        self.assertEqual(mock_isdir.call_count, 3)
+
+    @patch('os.listdir')
+    @patch('os.path.isdir')
+    def test_verify_policy_library_missing_library_raises_exception(self,
+                                                                    mock_isdir,
+                                                                    mock_listdir):
+        mock_isdir.side_effect = [False, True, True]
+        mock_listdir.side_effect = [['file1'], ['file1']]
+        self.assertRaises(errors.ConfigValidatorPolicyLibraryError, self.scanner.verify_policy_library)
+        self.assertEqual(mock_isdir.call_count, 1)
+
+    @patch('os.listdir')
+    @patch('os.path.isdir')
+    def test_verify_policy_library_success(self, mock_isdir, mock_listdir):
+        mock_listdir.side_effect = [['file1'], ['file1']]
+        mock_isdir.side_effect = [True, True, True]
+        self.scanner.verify_policy_library()
+        self.assertEqual(mock_listdir.call_count, 2)
+        self.assertEqual(mock_isdir.call_count, 3)


### PR DESCRIPTION
Check if policy library is setup correctly before running CV scanner if not then raise exception with helpful error message. Fix issue with the CV client exceptions.

Resolves #3383 