### PR TITLE
Test/scipt enabled scanner

### DIFF
--- a/integration_tests/tests/forseti/controls/scanner-enable_audit_logging_scanner.rb
+++ b/integration_tests/tests/forseti/controls/scanner-enable_audit_logging_scanner.rb
@@ -26,7 +26,7 @@ control 'scanner-enable-audit-logging-scanner' do
   end
 
   #  Enable audit logging Scanner
-  describe command("sudo python3 #{forseti_tests_path}/scripts/update_server_config.py audit_logging true") do
+  describe command("sudo python3 #{forseti_tests_path}/scripts/update_server_config.py enable_scanner audit_logging") do
     its('exit_status') { should eq 0 }
   end
   describe command("forseti server configuration reload") do

--- a/integration_tests/tests/forseti/controls/scanner-enable_audit_logging_scanner.rb
+++ b/integration_tests/tests/forseti/controls/scanner-enable_audit_logging_scanner.rb
@@ -16,6 +16,7 @@ require 'json'
 require 'securerandom'
 
 model_name = SecureRandom.uuid.gsub!('-', '')
+forseti_tests_path = "/home/ubuntu/forseti-security/integration_tests/tests/forseti"
 
 control 'scanner-enable-audit-logging-scanner' do
   @inventory_id = /\"id\"\: \"([0-9]*)\"/.match(command("forseti inventory create --import_as #{model_name}").stdout)[1]
@@ -24,11 +25,8 @@ control 'scanner-enable-audit-logging-scanner' do
     its('exit_status') { should eq 0 }
   end
 
-  # update server config to enable audit logging scanner
-  @modified_yaml = yaml('/home/ubuntu/forseti-security/configs/forseti_conf_server.yaml').params
-  @scanner_index = @modified_yaml["scanner"]["scanners"].find_index { |scanner| scanner["name"] == "audit_logging" }
-  @modified_yaml["scanner"]["scanners"][@scanner_index]["enabled"] = true
-  describe command("echo -en \"#{@modified_yaml.to_yaml}\" | sudo tee /home/ubuntu/forseti-security/configs/forseti_conf_server.yaml") do
+  #  Enable audit logging Scanner
+  describe command("sudo python3 #{forseti_tests_path}/scripts/update_server_config.py audit_logging true") do
     its('exit_status') { should eq 0 }
   end
   describe command("forseti server configuration reload") do

--- a/integration_tests/tests/forseti/controls/scanner-enable_audit_logging_scanner.rb
+++ b/integration_tests/tests/forseti/controls/scanner-enable_audit_logging_scanner.rb
@@ -40,9 +40,8 @@ control 'scanner-enable-audit-logging-scanner' do
     its('stdout') { should match (/Scan completed/)}
   end
 
-  # disable audit logging scanner
-  @modified_yaml["scanner"]["scanners"][@scanner_index]["enabled"] = false
-  describe command("echo -en \"#{@modified_yaml.to_yaml}\" | sudo tee /home/ubuntu/forseti-security/configs/forseti_conf_server.yaml") do
+  #  Disable audit logging Scanner
+  describe command("sudo python3 #{forseti_tests_path}/scripts/update_server_config.py disable_scanner audit_logging") do
     its('exit_status') { should eq 0 }
   end
   describe command("forseti server configuration reload").result do

--- a/integration_tests/tests/forseti/controls/scanner-enabled_apis_scanner.rb
+++ b/integration_tests/tests/forseti/controls/scanner-enabled_apis_scanner.rb
@@ -35,7 +35,7 @@ control 'scanner-enabled-apis-scanner', :order => :defined do
   end
 
   # Enable enabled_apis Scanner
-  describe command("sudo python3 #{forseti_tests_path}/scripts/update_server_config.py enabled_apis true") do
+  describe command("sudo python3 #{forseti_tests_path}/scripts/update_server_config.py enable_scanner enabled_apis") do
     its('exit_status') { should eq 0 }
   end
 

--- a/integration_tests/tests/forseti/controls/scanner-enabled_apis_scanner.rb
+++ b/integration_tests/tests/forseti/controls/scanner-enabled_apis_scanner.rb
@@ -18,6 +18,7 @@ require 'securerandom'
 db_password = attribute('forseti-cloudsql-password')
 db_user_name = attribute('forseti-cloudsql-user')
 forseti_server_bucket = attribute('forseti-server-storage-bucket')
+forseti_tests_path = "/home/ubuntu/forseti-security/integration_tests/tests/forseti"
 model_name = SecureRandom.uuid.gsub!('-', '')[0..10]
 project_id = attribute('project_id')
 
@@ -33,13 +34,11 @@ control 'scanner-enabled-apis-scanner', :order => :defined do
     its('exit_status') { should eq 0 }
   end
 
-  # Enable Scanner
-  @modified_yaml = yaml('/home/ubuntu/forseti-security/configs/forseti_conf_server.yaml').params
-  @scanner_index = @modified_yaml["scanner"]["scanners"].find_index { |scanner| scanner["name"] == "enabled_apis" }
-  @modified_yaml["scanner"]["scanners"][@scanner_index]["enabled"] = true
-  describe command("echo -en \"#{@modified_yaml.to_yaml}\" | sudo tee /home/ubuntu/forseti-security/configs/forseti_conf_server.yaml") do
+  # Enable enabled_apis Scanner
+  describe command("sudo python3 #{forseti_tests_path}/scripts/update_server_config.py enabled_apis true") do
     its('exit_status') { should eq 0 }
   end
+
   describe command("forseti server configuration reload") do
     its('exit_status') { should eq 0 }
     its('stdout') { should match (/\"isSuccess\": true/) }

--- a/integration_tests/tests/forseti/controls/scanner-enabled_apis_scanner.rb
+++ b/integration_tests/tests/forseti/controls/scanner-enabled_apis_scanner.rb
@@ -62,8 +62,7 @@ control 'scanner-enabled-apis-scanner', :order => :defined do
   end
 
   # Disable Scanner
-  @modified_yaml["scanner"]["scanners"][@scanner_index]["enabled"] = false
-  describe command("echo -en \"#{@modified_yaml.to_yaml}\" | sudo tee /home/ubuntu/forseti-security/configs/forseti_conf_server.yaml") do
+  describe command("sudo python3 #{forseti_tests_path}/scripts/update_server_config.py disable_scanner enabled_apis") do
     its('exit_status') { should eq 0 }
   end
   describe command("forseti server configuration reload") do

--- a/integration_tests/tests/forseti/scripts/update_server_config.py
+++ b/integration_tests/tests/forseti/scripts/update_server_config.py
@@ -87,6 +87,31 @@ class ServerConfigActions:
             print(f'ERROR: Unable to write server config. {e}')
             sys.exit(-3)
 
+    @staticmethod
+    def enable_scanner(scanner_name):
+        try:
+            config = ServerConfigActions.read_server_config()
+            for i in range(len(config['scanner']['scanners'])):
+                if config['scanner']['scanners'][i]["name"] == scanner_name:
+                    config['scanner']['scanners'][i]["enabled"] = True
+            ServerConfigActions.write_server_config(config)
+            print(f'Successfully set {scanner_name} scanner enabled...')
+        except Exception as e:
+            print(f'ERROR: Unable to set {scanner_name} scanner enabled. {e}')
+            sys.exit(2)
+
+    @staticmethod
+    def disable_scanner(scanner_name):
+        try:
+            config = ServerConfigActions.read_server_config()
+            for i in range(len(config['scanner']['scanners'])):
+                if config['scanner']['scanners'][i]["name"] == scanner_name:
+                    config['scanner']['scanners'][i]["enabled"] = False
+            ServerConfigActions.write_server_config(config)
+            print(f'Successfully set {scanner_name} scanner disabled...')
+        except Exception as e:
+            print(f'ERROR: Unable to set {scanner_name} scanner disabled. {e}')
+            sys.exit(2)
 
 if __name__ == '__main__':
     if len(sys.argv) < 2:

--- a/integration_tests/tests/forseti/scripts/update_server_config.py
+++ b/integration_tests/tests/forseti/scripts/update_server_config.py
@@ -91,9 +91,17 @@ class ServerConfigActions:
     def enable_scanner(scanner_name):
         try:
             config = ServerConfigActions.read_server_config()
+            not_found = True
             for i in range(len(config['scanner']['scanners'])):
                 if config['scanner']['scanners'][i]["name"] == scanner_name:
                     config['scanner']['scanners'][i]["enabled"] = True
+                    not_found = False
+                    break
+
+            if not_found:
+                print(f'ERROR: Unable to set {scanner_name} scanner enabled. Not found.')
+                sys.exit(2)
+
             ServerConfigActions.write_server_config(config)
             print(f'Successfully set {scanner_name} scanner enabled...')
         except Exception as e:
@@ -104,14 +112,23 @@ class ServerConfigActions:
     def disable_scanner(scanner_name):
         try:
             config = ServerConfigActions.read_server_config()
+            not_found = True
             for i in range(len(config['scanner']['scanners'])):
                 if config['scanner']['scanners'][i]["name"] == scanner_name:
                     config['scanner']['scanners'][i]["enabled"] = False
+                    not_found = False
+                    break
+
+            if not_found:
+                print(f'ERROR: Unable to set {scanner_name} scanner enabled. Not found.')
+                sys.exit(2)
+
             ServerConfigActions.write_server_config(config)
             print(f'Successfully set {scanner_name} scanner disabled...')
         except Exception as e:
             print(f'ERROR: Unable to set {scanner_name} scanner disabled. {e}')
             sys.exit(2)
+
 
 if __name__ == '__main__':
     if len(sys.argv) < 2:


### PR DESCRIPTION
...........F.............

Profile: forseti_integration_testing
Version: (not specified)
Target:  ssh://ubuntu@10.128.15.218:22

  ×  scanner-enabled-apis-scanner: Command: `forseti model use c0cabdb8934` (1 failed)
     ✔  Command: `forseti model use c0cabdb8934` exit_status should eq 0
     ✔  Command: `sudo gsutil cp -r gs://forseti-server-98c88382/rules $FORSETI_HOME/` exit_status should eq 0
     ✔  Command: `sudo python3 /home/ubuntu/forseti-security/integration_tests/tests/forseti/scripts/update_server_config.py enable_scanner enabled_apis` exit_status should eq 0
     ✔  Command: `forseti server configuration reload` exit_status should eq 0
     ✔  Command: `forseti server configuration reload` stdout should match /\"isSuccess\": true/
     ✔  Command: `sleep 10` exit_status should eq 0
     ✔  Command: `forseti scanner run` exit_status should eq 0
     ✔  Command: `forseti scanner run` stdout should match /EnabledApisScanner/
     ✔  Command: `forseti scanner run` stdout should match /Scan completed/
     ✔  Command: `forseti scanner run` stdout should match /Scanner Index ID: .*([0-9]*) is created/
     ✔  Command: `mysql -u forseti_security_user -pvz5nfmAkGsDVt8kl --host 127.0.0.1 --database forseti_security --execute "SELECT COUNT(*) FROM violations V JOIN forseti_security.scanner_index SI ON SI.id = V.scanner_index_id WHERE SI.inventory_index_id = 1579688212707143 AND V.violation_type = 'ENABLED_APIS_VIOLATION' AND V.resource_id = 'va-test-project-256619' AND V.rule_name = 'Enabled APIs blacklist';"` exit_status should eq 0
     ×  Command: `mysql -u forseti_security_user -pvz5nfmAkGsDVt8kl --host 127.0.0.1 --database forseti_security --execute "SELECT COUNT(*) FROM violations V JOIN forseti_security.scanner_index SI ON SI.id = V.scanner_index_id WHERE SI.inventory_index_id = 1579688212707143 AND V.violation_type = 'ENABLED_APIS_VIOLATION' AND V.resource_id = 'va-test-project-256619' AND V.rule_name = 'Enabled APIs blacklist';"` stdout should match /1/
     expected "COUNT(*)\n0\n" to match /1/
     Diff:
     @@ -1,2 +1,3 @@
     -/1/
     +COUNT(*)
     +0

     ✔  Command: `sudo python3 /home/ubuntu/forseti-security/integration_tests/tests/forseti/scripts/update_server_config.py disable_scanner enabled_apis` exit_status should eq 0
     ✔  Command: `forseti server configuration reload` exit_status should eq 0
     ✔  Command: `forseti server configuration reload` stdout should match /\"isSuccess\": true/
  ✔  scanner-enable-audit-logging-scanner: Command: `forseti model use 1bf7948ea3bb4a20adb1407b7b8dc0b3`
     ✔  Command: `forseti model use 1bf7948ea3bb4a20adb1407b7b8dc0b3` exit_status should eq 0
     ✔  Command: `sudo python3 /home/ubuntu/forseti-security/integration_tests/tests/forseti/scripts/update_server_config.py enable_scanner audit_logging` exit_status should eq 0
     ✔  Command: `forseti server configuration reload` exit_status should eq 0
     ✔  Command: `forseti scanner run` exit_status should eq 0
     ✔  Command: `forseti scanner run` stdout should match /AuditLoggingScanner/
     ✔  Command: `forseti scanner run` stdout should match /Scan completed/
     ✔  Command: `sudo python3 /home/ubuntu/forseti-security/integration_tests/tests/forseti/scripts/update_server_config.py disable_scanner audit_logging` exit_status should eq 0
     ✔  #<struct Train::Extras::CommandResult stdout="{\n  \"isSuccess\": true,\n  \"errorMessage\": \"\"\n}\n", stderr="", exit_status=0> exit_status should eq 0
     ✔  Command: `forseti inventory delete 1579693903512951` exit_status should eq 0
     ✔  Command: `forseti model delete 1bf7948ea3bb4a20adb1407b7b8dc0b3` exit_status should eq 0


Profile Summary: 1 successful control, 1 control failure, 0 controls skipped
Test Summary: 24 successful, 1 failure, 0 skipped