### PR TITLE
Restart Forseti to release used memory

### DIFF
--- a/install/gcp/scripts/run_forseti.sh
+++ b/install/gcp/scripts/run_forseti.sh
@@ -94,3 +94,7 @@ echo "Finished running Forseti notifier."
 # Clean up the model tables
 echo "Cleaning up model tables"
 forseti model delete ${MODEL_NAME}
+
+# Restart Forseti to release used memory
+systemctl restart forseti
+


### PR DESCRIPTION
Resolves part of #3425, #3557 and #3576 

This PR releases used up memory by restarting Forseti to prevent potential crash and undesired behavior reported in #3576 that is caused by memory not released after a process is completed. 

The change made in this PR was tested on three projects with instances with different versions/instance sizes/violations generated. 

- [x] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [x] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [x] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [x] My PR has been functionally tested.
- [x] All of the [tests](https://forsetisecurity.org/docs/latest/develop/dev/testing.html) pass.


