### PR TITLE
Pinned `idna==2.8` to satisfy `requests[security]==2.21.0`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ REQUIRED_PACKAGES = [
     'google-api-python-client==1.7.10',
     'google-auth==1.6.3',
     'google-auth-httplib2==0.0.3',
+    'idna==2.8',
     'Jinja2==2.10.1',
     'jmespath==0.9.3',
     'netaddr==0.7.19',


### PR DESCRIPTION
The existing `requests[security]==2.21.0` requires `idna>=2.5,<2.9`. 

However, `idna` just released `2.9` a few days ago, and it broke Forseti installation on VM startup using terraform-google-forseti.

This PR pins `idna` to `2.8`.

Related: https://github.com/forseti-security/terraform-google-forseti/issues/513

---
- [x] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [x] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [x] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [x] My PR has been functionally tested.
- [x] All of the [tests](https://forsetisecurity.org/docs/latest/develop/dev/testing.html) pass.
- [x] I have submitted a corresponding PR for documentation in the `forsetisecurity.org-dev branch` and included this on this PR (if applicable).
- [x] My documentation has been functionally tested and used (if applicable).
- [ ] I have submitted a corresponding PR in the [Forseti Terraform module](https://github.com/forseti-security/terraform-google-forseti) (if applicable).

These guidelines and more can be found in our [contributing guidelines](https://github.com/forseti-security/forseti-security/blob/dev/.github/CONTRIBUTING.md).
