### PR TITLE
Disable purge control

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -61,7 +61,7 @@ suites:
             - inventory-delete
             - inventory-get-list
             - inventory-performance
-            - inventory-purge
+#            - inventory-purge
             - logs-debug-level
             - model-create-get
             - model-delete


### PR DESCRIPTION
Disabling this control because it is running at the same time as other controls and deleting the inventories used for the tests.

Resolves #3722 