### PR TITLE
Remove the CV reset call from the scanner and client.

### DIFF
--- a/google/cloud/forseti/scanner/scanners/config_validator_scanner.py
+++ b/google/cloud/forseti/scanner/scanners/config_validator_scanner.py
@@ -174,9 +174,6 @@ class ConfigValidatorScanner(base_scanner.BaseScanner):
         Yields:
             list: A list of flattened violations.
         """
-        # Clean up the validator environment by doing a reset pre audit.
-        self.validator_client.reset()
-
         # Get all the data in Config Validator Asset format.
         cv_assets = self._retrieve(iam_policy=iam_policy)
 

--- a/google/cloud/forseti/scanner/scanners/config_validator_util/errors.py
+++ b/google/cloud/forseti/scanner/scanners/config_validator_util/errors.py
@@ -30,11 +30,6 @@ class ConfigValidatorPolicyLibraryError(Exception):
     pass
 
 
-class ConfigValidatorResetError(Exception):
-    """ConfigValidator Reset Error."""
-    pass
-
-
 class ConfigValidatorServerUnavailableError(Exception):
     """ConfigValidator Server Unavailable Error."""
     pass

--- a/google/cloud/forseti/scanner/scanners/config_validator_util/validator_client.py
+++ b/google/cloud/forseti/scanner/scanners/config_validator_util/validator_client.py
@@ -182,26 +182,6 @@ class ValidatorClient(object):
                 LOGGER.exception('ConfigValidatorAuditError: %s', e)
                 raise errors.ConfigValidatorAuditError(e)
 
-    @retry(retry_on_exception=retryable_exceptions.is_retryable_exception_cv,
-           wait_exponential_multiplier=10, wait_exponential_max=100,
-           stop_max_attempt_number=5)
-    def reset(self):
-        """Clears previously added data from Config Validator.
-
-        Raises:
-            ConfigValidatorResetError: Config Validator Reset Error.
-            ConfigValidatorServerUnavailableError: Config Validator Server
-                Unavailable Error."""
-        try:
-            self.stub.Reset(validator_pb2.ResetRequest())
-        except grpc.RpcError as e:
-            # pylint: disable=no-member
-            if e.code() == grpc.StatusCode.UNAVAILABLE:
-                raise errors.ConfigValidatorServerUnavailableError(e)
-            else:
-                LOGGER.exception('ConfigValidatorResetError: %s', e)
-                raise errors.ConfigValidatorResetError(e)
-
 
 class BufferedCVDataSender(object):
     """Buffered Config Validator data sender."""


### PR DESCRIPTION
Recent versions of Config Validator do not support the reset method as it is not required anymore. Will submit a PR to update the version of CV in the Terraform repo shortly.

Resolves #3681 