### PR TITLE
Added logging API to Turbinia TF deployment

### DIFF
--- a/contrib/incident-response/infrastructure/modules/turbinia/main.tf
+++ b/contrib/incident-response/infrastructure/modules/turbinia/main.tf
@@ -22,7 +22,8 @@ locals {
     "datastore.googleapis.com",
     "iam.googleapis.com",
     "pubsub.googleapis.com",
-    "storage-component.googleapis.com"
+    "storage-component.googleapis.com",
+    "logging.googleapis.com"
   ]
   # Cloud functions to deploy
   cloudfunctions_list = [


### PR DESCRIPTION
This PR adds the <b>logging.googleapis.com</b> to the list of API services to enabled for the Turbinia terraform deployment. This was done to allow for a new feature that allows for Stackdriver Logging in Turbinia to be integrated per: https://github.com/google/turbinia/pull/509

I've tested by standing up a new GCP project then running <b>forseti-security/contrib/incident-response/infrastructure/deploy.sh</b> with the new addition and confirmed in the terraform output that the logging service addition was being recognized/enabled through the deployment script.