### PR TITLE
Fix Policy Library links on website

### DIFF
--- a/_includes/docs/latest/migrating-to-rego/bigquery-dataset-acl.md
+++ b/_includes/docs/latest/migrating-to-rego/bigquery-dataset-acl.md
@@ -1,14 +1,14 @@
 ## BigQuery Dataset ACL
 
 **Description:** BigQuery datasets have access properties that can publicly 
-expose your datasets. The BigQuery scanner supports blacklist and whitelist 
+expose your datasets. The BigQuery scanner supports denylist and allowlist 
 modes to ensure unauthorized users don’t gain access to your datasets, and only 
 authorized users can gain access.
 
 {: .table .table-striped}
 | Python Scanner | Rego Constraint Template | Constraint Sample
 | ------------- | ------------- | -----------------
-| [bigquery_rules.yaml](https://github.com/forseti-security/terraform-google-forseti/blob/master/modules/rules/templates/rules/bigquery_rules.yaml) | [gcp_iam_allowed_bindings_v1.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_iam_allowed_bindings_v1.yaml) | [iam_blacklist_public.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/iam_blacklist_public.yaml)
+| [bigquery_rules.yaml](https://github.com/forseti-security/terraform-google-forseti/blob/master/modules/rules/templates/rules/bigquery_rules.yaml) | [gcp_iam_allowed_bindings.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_iam_allowed_bindings.yaml) | [iam_deny_public.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/iam_deny_public.yaml)
 
 ### Rego constraint asset type
 
@@ -56,24 +56,24 @@ by groups with `googlegroups.com` addresses.
 ```
 
 Add the Rego constraint template 
-[gcp_iam_allowed_bindings_v1.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_iam_allowed_bindings_v1.yaml) 
+[gcp_iam_allowed_bindings.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_iam_allowed_bindings.yaml) 
 in your `policies/templates/`directory.
 
 Create a new yaml file in your `policies/constraints/`directory with the following:
 
-`bigquery_rules_iam_blacklist_googlegroups.yaml`:
+`bigquery_rules_iam_denylist_googlegroups.yaml`:
 ```
 apiVersion: constraints.gatekeeper.sh/v1alpha1
-kind: GCPIAMAllowedBindingsConstraintV1
+kind: GCPIAMAllowedBindingsConstraintV3
 metadata:
-  name: bigquery_rules_iam_blacklist_googlegroups
+  name: bigquery_rules_iam_denylist_googlegroups
 spec:
   match:
     target: [“organizations/123456”]
   parameters:
-    mode: “blacklist”
-    assetType: “bigquery.googleapis.com/Dataset”
-    role: "roles/*"
+    mode: denylist
+    assetType: bigquery.googleapis.com/Dataset
+    role: roles/*
     members:
     - "group:*@googlegroups.com"
 ```

--- a/_includes/docs/latest/migrating-to-rego/bucket-acl.md
+++ b/_includes/docs/latest/migrating-to-rego/bucket-acl.md
@@ -2,13 +2,13 @@
 
 **Description:** Cloud Storage buckets have ACLs that can grant public access 
 to your Cloud Storage bucket and objects. The bucket scanner supports a 
-blacklist mode, to ensure unauthorized users don’t gain access to your 
+denylist mode, to ensure unauthorized users don’t gain access to your 
 Cloud Storage bucket.
 
 {: .table .table-striped}
 | Python Scanner | Rego Constraint Template | Constraint Sample
 | ------------- | ------------- | -----------------
-| [bucket_rules.yaml](https://github.com/forseti-security/terraform-google-forseti/blob/master/modules/rules/templates/rules/bucket_rules.yaml) | [gcp_storage_bucket_world_readable_v1.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_storage_bucket_world_readable_v1.yaml) | [storage_blacklist_public.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/storage_blacklist_public.yaml)
+| [bucket_rules.yaml](https://github.com/forseti-security/terraform-google-forseti/blob/master/modules/rules/templates/rules/bucket_rules.yaml) | [gcp_storage_bucket_world_readable_v1.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_storage_bucket_world_readable_v1.yaml) | [storage_denylist_public.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/storage_denylist_public.yaml)
 
 ### Rego constraint asset type
 
@@ -56,12 +56,12 @@ in your `policies/templates/`directory.
 
 Create a new yaml file in your `policies/constraints/`directory with the following:
 
-`storage_blacklist_public.yaml`:
+`storage_denylist_public.yaml`:
 ```
 apiVersion: constraints.gatekeeper.sh/v1alpha1
 kind: GCPStorageBucketWorldReadableConstraintV1
 metadata:
-  name: blacklist_public_users
+  name: denylist_public_users
 spec:
   match:
     target: [“organizations/123456”]

--- a/_includes/docs/latest/migrating-to-rego/cloud-sql.md
+++ b/_includes/docs/latest/migrating-to-rego/cloud-sql.md
@@ -1,7 +1,7 @@
 ## Cloud SQL
 
 **Description:** Cloud SQL instances can be configured to grant external 
-networks access. The Cloud SQL scanner supports a blacklist mode, to ensure 
+networks access. The Cloud SQL scanner supports a denylist mode, to ensure 
 unauthorized users don’t gain access to your Cloud SQL instances.
 
 {: .table .table-striped}

--- a/_includes/docs/latest/migrating-to-rego/enabled-apis.md
+++ b/_includes/docs/latest/migrating-to-rego/enabled-apis.md
@@ -1,7 +1,7 @@
 ## Enabled APIs
 
 **Description:** The Enabled APIs scanner detects if a project has appropriate 
-APIs enabled. It supports whitelisting supported APIs, blacklisting unsupported 
+APIs enabled. It supports allowlisting supported APIs, denylisting unsupported 
 APIs, and specifying required APIs that must be enabled.
 
 {: .table .table-striped}
@@ -32,7 +32,7 @@ for any APIs that are not listed in the allowed services defined.
 
 `enabled_apis_rules.yaml`:
 ```
-   - name: Example Enabled APIs whitelist
+   - name: Example Enabled APIs allowlist
      mode: whitelist
      resource:
        - type: project

--- a/_includes/docs/latest/migrating-to-rego/iam-policy.md
+++ b/_includes/docs/latest/migrating-to-rego/iam-policy.md
@@ -2,12 +2,12 @@
 **Description:** Cloud IAM policies directly grant access on GCP. To ensure 
 only authorized members and permissions are granted in Cloud IAM policies, 
 IAM policy scanner supports the following:
-- Whitelist, blacklist, and required modes.
+- Allowlist, denylist, and required modes.
 
 {: .table .table-striped}
 | Python Scanner | Rego Constraint Template | Constraint Sample
 | ------------- | ------------- | -----------------
-| [iam_rules.yaml](https://github.com/forseti-security/terraform-google-forseti/blob/master/modules/rules/templates/rules/iam_rules.yaml) | [gcp_iam_allowed_bindings_v1.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_iam_allowed_bindings_v1.yaml)<br><br>[gcp_iam_required_bindings_v1.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_iam_required_bindings_v1.yaml) | [iam_allowed_roles.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/iam_allowed_roles.yaml)<br><br>[iam_restrict_gmail.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/iam_restrict_gmail.yaml)<br><br>[iam_blacklist_role.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/iam_blacklist_role.yaml)<br><br>[iam_blacklist_service_account_creator_role.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/iam_blacklist_service_account_creator_role.yaml)<br><br>[iam_blacklist_public.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/iam_blacklist_public.yaml)<br><br>[iam_restrict_role.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/iam_restrict_role.yaml)<br><br>[iam_required_roles.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/iam_required_roles.yaml)
+| [iam_rules.yaml](https://github.com/forseti-security/terraform-google-forseti/blob/master/modules/rules/templates/rules/iam_rules.yaml) | [gcp_iam_allowed_bindings.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_iam_allowed_bindings.yaml)<br><br>[gcp_iam_required_bindings_v1.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_iam_required_bindings_v1.yaml) | [iam_allowed_roles.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/iam_allowed_roles.yaml)<br><br>[iam_restrict_gmail.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/iam_restrict_gmail.yaml)<br><br>[iam_deny_role.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/iam_deny_role.yaml)<br><br>[iam_block_service_account_creator_role.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/iam_block_service_account_creator_role.yaml)<br><br>[iam_deny_public.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/iam_deny_public.yaml)<br><br>[iam_restrict_role.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/iam_restrict_role.yaml)<br><br>[iam_required_roles.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/iam_required_roles.yaml)
 
 ### Rego constraint asset type
 
@@ -18,7 +18,7 @@ E.g.
 
 ### Rego constraint properties
 
-[gcp_iam_allowed_bindings_v1.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_iam_allowed_bindings_v1.yaml) 
+[gcp_iam_allowed_bindings.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_iam_allowed_bindings.yaml) 
 
 {: .table .table-striped}
 | Python Scanner field | Rego Constraint field
@@ -80,43 +80,43 @@ The following Python scanner rules utilizes the IAM Policy scanner to:
 ```
 
 Add the Rego constraint template 
-[gcp_iam_allowed_bindings_v1.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_iam_allowed_bindings_v1.yaml) 
+[gcp_iam_allowed_bindings.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_iam_allowed_bindings.yaml) 
 in your `policies/templates/`directory.
 
 Create a new yaml file in your `policies/constraints/`directory with the following:
 
-`iam_whitelist_domain.yaml`:
+`iam_allowlist_domain.yaml`:
 ```
 apiVersion: constraints.gatekeeper.sh/v1alpha1
-kind: GCPIAMAllowedBindingsConstraintV1
+kind: GCPIAMAllowedBindingsConstraintV3
 metadata:
-  name: whitelist_domain
+  name: allowlist_domain
 spec:
   severity: high
   match:
     target: ["organizations/123456"]
   parameters:
-    mode: whitelist
-    role: “roles/resourcemanager.organizationAdmin”
+    mode: allowlist
+    role: roles/resourcemanager.organizationAdmin
     members:
     - "user:*@my-cool-domain.com"
     - “group:*@my-cool-domain.com”
 ```
 
-`iam_blacklist_public.yaml`:
+`iam_deny_public.yaml`:
 ```
 apiVersion: constraints.gatekeeper.sh/v1alpha1
-kind: GCPIAMAllowedBindingsConstraintV1
+kind: GCPIAMAllowedBindingsConstraintV3
 metadata:
-  name: blacklist_all_users
+  name: deny_allusers
 spec:
   severity: high
   match:
     target: ["organizations/123456"]
   parameters:
-    mode: blacklist
-    assetType: “storage.googleapis.com/Bucket”
-    role: "roles/*"
+    mode: denylist
+    assetType: storage.googleapis.com/Bucket
+    role: roles/*
     members:
     - "allUsers"
     - "allAuthenticatedUsers"

--- a/_includes/docs/latest/migrating-to-rego/instance-network-interface.md
+++ b/_includes/docs/latest/migrating-to-rego/instance-network-interface.md
@@ -9,7 +9,7 @@ trusted networks.
 {: .table .table-striped}
 | Python Scanner | Rego Constraint Template | Constraint Sample
 | ------------- | ------------- | -----------------
-| [instance_network_interface_<br>rules.yaml](https://github.com/forseti-security/terraform-google-forseti/blob/master/modules/rules/templates/rules/instance_network_interface_rules.yaml) | [gcp_compute_network_interface_<br>whitelist_v1.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_compute_network_interface_whitelist_v1.yaml) | [compute_network_interface_<br>whitelist.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/compute_network_interface_whitelist.yaml)
+| [instance_network_interface_<br>rules.yaml](https://github.com/forseti-security/terraform-google-forseti/blob/master/modules/rules/templates/rules/instance_network_interface_rules.yaml) | [gcp_compute_allowed_networks.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_compute_allowed_networks.yaml) | [compute_allowed_networks.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/compute_allowed_networks.yaml)
 
 ### Rego constraint asset type
 
@@ -24,18 +24,18 @@ This Rego constraint scans IAM policies for the following CAI asset types:
 | ------------- | -------------
 | name | metadata.name
 | project | metadata.spec.match.target
-| whitelist | metadata.spec.parameters.whitelist
+| whitelist | metadata.spec.parameters.allowed
 
 ### Python scanner to Rego constraint sample
 
 The following Python scanner rule utilizes the Instance Network Interface 
-scanner to ensure instances with external IPs are only running on whitelisted 
+scanner to ensure instances with external IPs are only running on allowlisted 
 networks and instances are only running on networks created in allowed projects 
 (using XPN)
 
 `instance_network_interface_rules.yaml`:
 ```
-- name: all networks covered in whitelist
+- name: all networks covered in allowlist
   project: '*'
   network: '*'
   is_external_network: True
@@ -51,25 +51,25 @@ networks and instances are only running on networks created in allowed projects
 ```
 
 Add the Rego constraint template 
-[gcp_compute_network_interface_whitelist_v1.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_compute_network_interface_whitelist_v1.yaml) 
+[gcp_compute_allowed_networks.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_compute_allowed_networks.yaml) 
 in your `policies/templates/`directory.
 
 Create a new yaml file in your `policies/constraints/`directory with the following:
 
-`compute_network_interface_whitelist.yaml`:
+`gcp_compute_allowed_networks.yaml`:
 ```
 apiVersion: constraints.gatekeeper.sh/v1alpha1
-kind: GCPComputeNetworkInterfaceWhitelistConstraintV1
+kind: GCPComputeAllowedNetworksConstraintV2
 metadata:
-  name: whitelist_compute_network_interface
+  name: allowed-networks
 spec:
   severity: high
   match:
     gcp:
       target: ["organizations/123456"]
   parameters:
-      whitelist:
-          - https://www.googleapis.com/compute/v1/projects/project-1/global/networks/network-1
+      allowed:
+         - https://www.googleapis.com/compute/v1/projects/project-1/global/networks/network-1
          - https://www.googleapis.com/compute/v1/projects/project-2/global/networks/network-2
          - https://www.googleapis.com/compute/v1/projects/project-2/global/networks/network-2-2
          - https://www.googleapis.com/compute/v1/projects/project-3/global/networks/network-3

--- a/_includes/docs/latest/migrating-to-rego/kubernetes-engine.md
+++ b/_includes/docs/latest/migrating-to-rego/kubernetes-engine.md
@@ -8,7 +8,7 @@ for violations. It supports the following features:
 
 - Any cluster property can be checked in a rule by providing a JMESPath expression that extracts the right fields.
 See http://jmespath.org/ for a tutorial and detailed specifications.
-- Rules can be whitelists or blacklists.
+- Rules can be allowlists or denylists.
 
 {: .table .table-striped}
 | Python Scanner | Rego Constraint Template | Constraint Sample

--- a/_includes/docs/latest/migrating-to-rego/load-balancing-forwarding-rules.md
+++ b/_includes/docs/latest/migrating-to-rego/load-balancing-forwarding-rules.md
@@ -2,13 +2,13 @@
 
 **Description:** You can configure load balancer forwarding rules to direct 
 unauthorized external traffic to your target instances. The forwarding rule 
-scanner supports a whitelist mode, to ensure each forwarding rule only directs 
+scanner supports an allowlist mode, to ensure each forwarding rule only directs 
 to the intended target instances.
 
 {: .table .table-striped}
 | Python Scanner | Rego Constraint Template | Constraint Sample
 | ------------- | ------------- | -----------------
-| [forwarding_rules.yaml](https://github.com/forseti-security/terraform-google-forseti/blob/master/modules/rules/templates/rules/forwarding_rules.yaml) | [gcp_lb_forwarding_rules_whitelist.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_lb_forwarding_rules_whitelist.yaml)<br><br>[gcp_glb_external_ip_access_constraint_v1.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_glb_external_ip_access_constraint_v1.yaml) | [gcp_lb_forwarding_rules_whitelist.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/gcp_lb_forwarding_rules_whitelist.yaml)<br><br>[gcp_glb_external_ip.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/gcp_glb_external_ip.yaml)
+| [forwarding_rules.yaml](https://github.com/forseti-security/terraform-google-forseti/blob/master/modules/rules/templates/rules/forwarding_rules.yaml) | [gcp_lb_forwarding_rules.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_lb_forwarding_rules.yaml)<br><br>[gcp_glb_external_ip_access_constraint_v1.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_glb_external_ip_access_constraint_v1.yaml) | [gcp_lb_forwarding.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/gcp_lb_forwarding.yaml)<br><br>[gcp_glb_external_ip.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/gcp_glb_external_ip.yaml)
 
 ### Rego constraint asset type
 
@@ -19,14 +19,14 @@ The Rego constraints scan for the following CAI asset types:
 
 ### Rego constraint properties
 
-[gcp_lb_forwarding_rules_whitelist.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_lb_forwarding_rules_whitelist.yaml)
+[gcp_lb_forwarding_rules.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_lb_forwarding_rules.yaml)
 
 {: .table .table-striped}
 | Python Scanner field | Rego Constraint field
 | ------------- | -------------
 | name | metadata.name
 | target | metadata.spec.parameters.target
-| mode | metadata.spec.parameters.whitelist
+| mode | metadata.spec.parameters.allowlist
 | load_balancing_scheme | metadata.spec.parameters.load_balancing_scheme
 | ip_protocol | metadata.spec.parameters.ip_protocol
 | ip_address | metadata.spec.parameters.ip_address
@@ -49,21 +49,21 @@ scanner to only allow UDP load balancers for external VPN.
 ```
 
 Add the Rego constraint template 
-[gcp_lb_forwarding_rules_whitelist.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_lb_forwarding_rules_whitelist.yaml) 
+[gcp_lb_forwarding_rules.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_lb_forwarding_rules.yaml) 
 in your `policies/templates/`directory.
 
 Create a new yaml file in your `policies/constraints/`directory with the following:
 
-`gcp_lb_forwarding_rule_whitelist`:
+`gcp_lb_forwarding_rules.yaml`:
 ```
 apiVersion: constraints.gatekeeper.sh/v1alpha1
-kind: GCPLBForwardingRuleWhitelistConstraintV1
+kind: GCPLBAllowedForwardingRulesConstraintV2
 metadata:
-  name: gcp_lb_forwarding_rule_whitelist
+  name: gcp_lb_forwarding_rule_allowlist
 spec:
   severity: high
   parameters:
-    whitelist:
+    allowlist:
      - target: https://www.googleapis.com/compute/v1/projects/THEPROJECT/regions/us-central1/THELB/FWD_RULE_NAME
        load_balancing_scheme: EXTERNAL
        port_range: 4500-4500

--- a/_includes/docs/latest/migrating-to-rego/location.md
+++ b/_includes/docs/latest/migrating-to-rego/location.md
@@ -7,7 +7,7 @@ deployment.
 {: .table .table-striped}
 | Python Scanner | Rego Constraint Template | Constraint Sample
 | ------------- | ------------- | -----------------
-| [location_rules.yaml](https://github.com/forseti-security/terraform-google-forseti/blob/master/modules/rules/templates/rules/location_rules.yaml) | [gcp_storage_location_v1.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_storage_location_v1.yaml)<br><br>[gcp_sql_location_v1.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_sql_location_v1.yaml)<br><br>[gcp_bq_dataset_location_v1.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_bq_dataset_location_v1.yaml)<br><br>[gcp_gke_cluster_location_v2.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_gke_cluster_location_v2.yaml)<br><br>[gcp_compute_zone_v1.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_compute_zone_v1.yaml) | [storage_location.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/storage_location.yaml)<br><br>[sql_location.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/sql_location.yaml)<br><br>[bq_dataset_location.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/bq_dataset_location.yaml)<br><br>[gke_cluster_location.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/gke_cluster_location.yaml)<br><br>[compute_zone.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/compute_zone.yaml)
+| [location_rules.yaml](https://github.com/forseti-security/terraform-google-forseti/blob/master/modules/rules/templates/rules/location_rules.yaml) | [gcp_storage_location_v1.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_storage_location_v1.yaml)<br><br>[gcp_sql_location_v1.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_sql_location_v1.yaml)<br><br>[gcp_bq_dataset_location_v1.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_bq_dataset_location_v1.yaml)<br><br>[gcp_gke_cluster_location.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_gke_cluster_location.yaml)<br><br>[gcp_compute_zone_v1.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_compute_zone_v1.yaml) | [storage_location.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/storage_location.yaml)<br><br>[sql_location.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/sql_location.yaml)<br><br>[bq_dataset_location.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/bq_dataset_location.yaml)<br><br>[gke_cluster_location.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/gke_cluster_location.yaml)<br><br>[compute_zone.yaml](https://github.com/forseti-security/policy-library/blob/master/samples/compute_zone.yaml)
 
 ### Rego constraint asset type
 
@@ -23,7 +23,7 @@ deployment.
 
 - bigquery.googleapis.com/Dataset
 
-[gcp_gke_cluster_location_v2.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_gke_cluster_location_v2.yaml) scans for the following CAI asset types:
+[gcp_gke_cluster_location.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_gke_cluster_location.yaml) scans for the following CAI asset types:
 
 - container.googleapis.com/Cluster
 
@@ -68,7 +68,7 @@ deployment.
 | resource.resource_ids | metadata.spec.match.target
 | locations | metadata.spec.parameters.locations
 
-[gcp_gke_cluster_location_v2.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_gke_cluster_location_v2.yaml) 
+[gcp_gke_cluster_location.yaml](https://github.com/forseti-security/policy-library/blob/master/policies/templates/gcp_gke_cluster_location.yaml) 
 
 {: .table .table-striped}
 | Python Scanner field | Rego Constraint field


### PR DESCRIPTION
Update website for broken links to legacy Policy Library files. Update CV migration docs to replace whitelist/blacklist with allowlist/blacklist.

Resolves #3758 