### PR TITLE
Improve Forseti Config Validator website docs

### DIFF
--- a/_docs/_latest/configure/config-validator/index.md
+++ b/_docs/_latest/configure/config-validator/index.md
@@ -5,14 +5,14 @@ order: 700
 
 # {{ page.title }}
 
-This page lists the steps to set up Config Validator Scanner. 
+This page lists the steps to configure Config Validator with the Forseti Terraform module. Config Validator is 
+supported with Forseti on GCE and Forseti on GKE.
 
 ---
 
-## **Setting up Config Validator Scanner**
+## **Enable the Config Validator Scanner**
 
-In your `main.tf` file, set the `config_validator_enabled` variable in the 
-Forseti Terraform module to `"true"`:
+In your `main.tf` file, set the `config_validator_enabled` variable in the Forseti Terraform module to `true`:
 
 ```
 module "forseti" {
@@ -23,54 +23,50 @@ module "forseti" {
   
   ...
   
-  config_validator_enabled   = "true"
-  config_validator_image     = "CONFIG_VALIDATOR_IMAGE"
-  config_validator_image_tag = "CONFIG_VALIDATOR_IMAGE_TAG"
-}
+  config_validator_enabled = true
 ```
 
-**Note:**
-- You will be notified when Config Validator violations are found as 
-`config_validator_violations_should_notify` is set to `"true"` by default.
-- `config_validator_image` and `config_validator_image_tag` should be set 
-only when you want to use a specific Config Validator image or tag. Default 
-values can be found [here](https://github.com/forseti-security/terraform-google-forseti#inputs).
-Please reach out to the [Forseti Security Team](https://forsetisecurity.org/docs/latest/use/get-help.html) 
-to see if the specific Config Validator image/tag that you want to you use is 
-supported.
+### **Additional Config Validator variables**
 
-Apply the Terraform module.
+There are some additional Config Validator variables that can be set within the Terraform configuration:
+
+- `config_validator_image`: The path to the Config Validator image. **The default value is strongly recommended.**
+- `config_validator_image_tag`: The tag or version of the Config Validator image. **The default value is strongly 
+recommended.**
+- `config_validator_violations_should_notify`: Include Config Validator violations for any notifiers; this is enabled by
+default.
+
+## **Policy Library**
+
+Before deploying Forseti, the Policy Library will need to be set up so that Config Validator knows what to scan. The 
+Forseti Policy Library offers a great list of [sample constraints](https://github.com/forseti-security/policy-library/tree/master/samples) 
+that you can use to get started.
+
+You can provide policies to the Forseti Server in two ways:
+- [Sync policies from GCS (default behavior)]({% link _docs/latest/configure/config-validator/policy-library-sync-from-gcs.md %})
+- [Sync policies from a Git repository]({% link _docs/latest/configure/config-validator/policy-library-sync-from-git-repo.md %})
+
+## **Deploy Forseti with Config Validator**
+
+Once you have configured the Forseti Terraform module and set up a Policy Library, then deploy Forseti with Terraform.
 
 ```
 terraform apply
 ```
 
-At this point, you are ready to add your own constraints in your policy-library 
-and start scanning your infrastructure for violations based on them. The Forseti 
-project offers a great list of [sample constraints](https://github.com/forseti-security/policy-library/tree/master/samples) 
-you can use freely to get started.
+## **Logs and Troubleshooting**
 
-You can provide policies to the Forseti Server in two ways:
-- Sync policies from GCS to the Forseti Server (default behavior)
-- Enable the git sync feature to allow Forseti to automatically sync policy 
-updates to your Forseti Server to be used by future scans. 
-
-## **Troubleshooting**
-
-- You can find out what errors have happened by viewing any logs related to this 
-process from Operations Logging by searching for `config-validator`.
-- Operations Logging displays `All Logs` from the Forseti Server VM by default. 
-Change the log filter by selecting `forseti` from the drop-down menu to 
-view Forseti logs. Similarly, select `gcplogs-docker-driver` to view the
-docker logs for `config-validator` and `git-sync` services.   
-- You can also check that the config-validator service is running and healthy by 
-running the following command in the Forseti server VM:
+- Config Validator logs can be found in the Forseti server VM [Cloud logs](https://cloud.google.com/logging).
+- All Config Validator logs are logged to the `gcplogs-docker-driver` log with no log level.
+- To only view the Config Validator logs, select the `gcplogs-docker-driver` log and search for `config-validator`; 
+there are some other processes that log to the log as well, such as the git-sync process.
+- You can check that the config-validator service is actively running with the following command in the Forseti server 
+VM:
 
 ```bash
   sudo systemctl status config-validator
 ```
 
-## **What’s next**
-* Learn about syncing policies from GCS to the Forseti Server [here]({% link _docs/latest/configure/config-validator/policy-library-sync-from-gcs.md %}).
-* Learn about enabling the git sync feature to provide policies to the Forseti 
-Server [here]({% link _docs/latest/configure/config-validator/policy-library-sync-from-git-repo.md %}).
+## Support
+
+Please reach out to the [Forseti Security Team]({% link _docs/latest/use/get-help.md %}) for support.

--- a/_docs/_latest/configure/config-validator/policy-library-sync-from-gcs.md
+++ b/_docs/_latest/configure/config-validator/policy-library-sync-from-gcs.md
@@ -5,25 +5,25 @@ order: 701
 
 # {{ page.title }}
 
-This page describes how to sync policies from the GCS to the Forseti Server.
+This page describes how to sync policies from GCS to the Forseti Server. This feature is supported with Forseti on GCE 
+and Forseti on GKE.
 
 ---
 
 ## **Policy Library Sync From GCS**
 
-The default behavior of Forseti is to sync the Policy Library from the Forseti 
-Server GCS bucket. 
+The default behavior of Forseti is to sync the Policy Library from the Forseti Server GCS bucket. As part of the cron 
+job that collects an inventory and performs a scan, the policies will be copied down before each scan.
 
 To sync policies from GCS to the Forseti server, you will need to create the GCS folder.
 
-Open the Forseti project in the [Google Cloud Console](https://pantheon.corp.google.com/)
-and go to Storage in the menu. The Forseti Server bucket will be named 
-`forseti-server-{SUFFIX}` where `{SUFFIX}` is a random 8 character suffix setup 
-at the time Forseti is deployed. Create a folder with the name `policy-library` 
-inside the Forseti Server bucket and make note of the suffix.
+Open the Forseti project in the [Google Cloud Console](https://console.cloud.google.com/) and go to **Storage** in the 
+menu. The Forseti Server bucket will be named `forseti-server-{SUFFIX}` where `{SUFFIX}` is a random 8 character suffix 
+created at the time Forseti is deployed. Create a folder with the name `policy-library` inside the Forseti Server 
+bucket and make note of the suffix.
 
-Assuming you have a local copy of your policy library repository, you can follow 
-these steps to copy them to GCS (replace `{SUFFIX}` with the suffix noted above):
+Assuming you have a local copy of your policy library repository, you can follow these steps to copy them to GCS 
+(replace `{SUFFIX}` with the suffix noted above):
 
 ```
 export FORSETI_BUCKET=forseti-server-{SUFFIX}
@@ -31,10 +31,21 @@ export POLICY_LIBRARY_PATH=path/to/local/policy-library
 gsutil -m rsync -d -r ${POLICY_LIBRARY_PATH}/policies gs://${FORSETI_BUCKET}/policy-library/policies
 gsutil -m rsync -d -r ${POLICY_LIBRARY_PATH}/lib gs://${FORSETI_BUCKET}/policy-library/lib
 ```
-After this is done, Forseti will pick up the new policy library content in the 
-next scanner run.
+
+After this is done, Forseti will pick up the new policies in the next scanner run.
+
+## **Ad-hoc Scanning**
+
+If you would like to run an ad-hoc scan by connecting to the Forseti VMs via SSH, you can copy the policies from GCS and
+will need to restart the Config Validator service. **Note**: While a scan can be done from either of the VMs, you will
+need to SSH to copy the policies and restart Config Validator.
+
+```
+sudo mkdir -m 777 -p "$POLICY_LIBRARY_HOME/policy-library"
+sudo gsutil -m rsync -d -r "gs://$SCANNER_BUCKET/policy-library" "$POLICY_LIBRARY_HOME/policy-library"
+sudo systemctl restart config-validator
+```
 
 ## **What’s next**
-* Learn about end-to-end workflow with sample constraint [here](https://github.com/forseti-security/policy-library/blob/master/docs/user_guide.md#end-to-end-workflow-with-sample-constraint).
-* Learn about how to write your own constraints using pre-defined constraint
-template [here](https://github.com/forseti-security/policy-library/blob/master/docs/user_guide.md#how-to-set-up-constraints-with-policy-library).
+* Learn about the end-to-end workflow to apply a sample constraint [here](https://github.com/forseti-security/policy-library/blob/master/docs/user_guide.md#end-to-end-workflow-with-sample-constraint).
+* Learn how to customize a constraint [here](https://github.com/forseti-security/policy-library/blob/master/docs/user_guide.md#instantiate-constraints).

--- a/_docs/_latest/configure/config-validator/policy-library-sync-from-git-repo.md
+++ b/_docs/_latest/configure/config-validator/policy-library-sync-from-git-repo.md
@@ -5,25 +5,26 @@ order: 702
 
 # {{ page.title }}
 
-This page describes how to sync policies from Git repository.
+This page describes how to sync Config Validator policies to the Forseti server from a Git repository. This feature 
+uses the [git-sync image](https://github.com/kubernetes/git-sync) to sync any changes in a Git repository to the Forseti
+server VM. This feature is supported with Forseti on GCE and Forseti on GKE.
 
 ---
 
 ## **Policy Library Sync from Git Repository**
 
-As part of the Terraform configuration, you will need to include a few 
-additional variables to enable the git-sync feature.
+As part of the Terraform configuration, you will need to include a few additional variables to enable the git-sync 
+feature.
 
-Before configuring the config file, we recommend you to set up the Policy 
-Library repository by following the steps listed [here](https://github.com/forseti-security/policy-library/blob/master/docs/user_guide.md#how-to-set-up-constraints-with-policy-library) .
+First you will need to set up the Policy Library repository by following the steps listed 
+[here](https://github.com/forseti-security/policy-library/blob/master/docs/user_guide.md#how-to-set-up-constraints-with-policy-library).
 
-In your `main.tf` file, set the `policy_library_sync_enabled` variable in the 
-Forseti Terraform module to `"true"` to enable git-sync, and set the 
-`policy_library_repository_url` to the URL for your Policy Library repository; 
-git protocol is recommended.
+In the Forseti Terrraform `main.tf` file, set the `policy_library_sync_enabled` variable in the Forseti Terraform 
+module to `true` to enable git-sync, and set the `policy_library_repository_url` to the URL for your Policy Library 
+repository; the Git protocol is recommended.
 
-You can set the `policy_library_repository_branch` to the specific git branch
-containing the policies. By default, policies from the `master` branch are synced.
+You can set the `policy_library_repository_branch` to the specific git branch containing the policies. By default, 
+policies from the `master` branch are synced.
 
 ```
 module "forseti" {
@@ -34,17 +35,23 @@ module "forseti" {
   
   ...
   
-  config_validator_enabled          = "true"
-  policy_library_sync_enabled       = "true"
-  policy_library_repository_url     = "git@github.com:forseti-security/policy-library"
+  config_validator_enabled      = true
+  policy_library_sync_enabled   = true
+  policy_library_repository_url = "git@github.com:forseti-security/policy-library"
 }
 ```
 
 (OPTIONAL) `policy_library_sync_ssh_known_hosts`: Provide the [known host keys](https://www.ssh.com/ssh/host-key)
-for the git repository. This can be obtained by running ssh-keyscan 
-${YOUR_GIT_HOST}.
+for the git repository. This can be obtained by running ssh-keyscan ${YOUR_GIT_HOST}.
 
-You should also setup an outputs.tf configuration file for Terraform to obtain the auto-generated public SSH key.
+### **Important Note**
+
+In order to connect to the private Policy Library repository, Terraform will generate an SSH key that will need to be 
+added to the Git user account. Once the SSH key has been added, then the git-sync container will be able to clone the 
+repository on the Forseti server VM. [Follow these steps to add the SSH key to your account](https://help.github.com/en/github/authenticating-to-github/adding-a-new-ssh-key-to-your-github-account).
+
+You can set up a Terraform outputs.tf file for to obtain the auto-generated public SSH key. Example output for the SSH 
+key.
 
 ``` 
 output "forseti-server-git-public-key-openssh" {
@@ -53,29 +60,36 @@ output "forseti-server-git-public-key-openssh" {
 }
 ```
 
-**IMPORTANT:** After applying the Terraform configuration, you will need to add 
-the generated SSH key to the git user account. The SSH key will be provided as 
-an output from Terraform. If the Policy Library repository is hosted on GitHub, 
-you can [follow these steps to add the SSH key to your account](https://help.github.com/en/github/authenticating-to-github/adding-a-new-ssh-key-to-your-github-account).
-
 To obtain the generated SSH key from Terraform run this command:
 
 ```
 terraform output forseti-server-git-public-key-openssh
 ```
 
-You can view any logs related to this process from Stackdriver Logging by 
-searching for `git-sync`.
+## **Logs and Troubleshooting**
 
-**Note:**
-- The Config Validator service need to be restarted after policies are synced 
-over. This is done automatically by the cron job that runs every 2 hours by 
-default. However, if you are running ad-hoc scans, you can restart the Config
-Validator service to pick up the latest policies by running `sudo systemctl 
-restart config-validator`. You can check the status of the service by running
-`sudo systemctl status config-validator`.
+- Git-sync logs can be found in the Forseti server VM [Cloud logs](https://cloud.google.com/logging).
+- All git-sync logs are logged to the `gcplogs-docker-driver` log with no log level, along with the Config Validator 
+logs.
+- To only view the git-sync logs, select the `gcplogs-docker-driver` log and search for `git-sync`.
+- You can check that the git-sync service is actively running with the following command in the Forseti server 
+VM:
+
+```bash
+  sudo systemctl status policy-library-sync
+```
+
+## **Ad-hoc Scanning**
+
+After commiting changes to your private Git repository, you can run an ad-hoc scan by connecting to the Forseti server. 
+Those changes will be automatically synced to the Forseti server within 30 seconds. You can then SSH to the Forseti
+server and run a scan, however you will need to restart the Config Validator service. This step is automated as part of 
+the cron job. Run the following command to restart Config Validator:
+
+```
+sudo systemctl restart config-validator
+```
 
 ## **What’s next**
-* Learn about end-to-end workflow with sample constraint [here](https://github.com/forseti-security/policy-library/blob/master/docs/user_guide.md#end-to-end-workflow-with-sample-constraint).
-* Learn about how to write your own constraints using pre-defined constraint
-template [here](https://github.com/forseti-security/policy-library/blob/master/docs/user_guide.md#how-to-set-up-constraints-with-policy-library).
+* Learn about the end-to-end workflow to apply a sample constraint [here](https://github.com/forseti-security/policy-library/blob/master/docs/user_guide.md#end-to-end-workflow-with-sample-constraint).
+* Learn how to customize a constraint [here](https://github.com/forseti-security/policy-library/blob/master/docs/user_guide.md#instantiate-constraints).

--- a/_docs/_latest/configure/config-validator/upgrade-cv.md
+++ b/_docs/_latest/configure/config-validator/upgrade-cv.md
@@ -5,42 +5,72 @@ order: 703
 
 # {{ page.title }}
 
-This page describes how to upgrade Config Validator.
+This page describes how to upgrade the Config Validator version used by Forseti. These steps are typically performed by
+the Forseti Team to support a new Config Validator version for an upcoming Forseti release.
+
+Not all versions of Config Validator are backwards compatible with Forseti. It is recommended to use the default 
+version of Config Validator that is deployed as part of Terraform. Follow the steps on this page to upgrade to a new 
+version of Config Validator.
 
 ---
 
-## **Upgrade Config Validator**
+## **Generate Config Validator protos**
 
-Follow the steps below to upgrade Config Validator:
+In order to ensure a version of Config Validator is supported by Forseti, the validator proto files need to be generated
+from the branch/tag of Config Validator.
 
-- Run the following commands to generate protos for [validator_pb2.py](https://github.com/forseti-security/forseti-security/blob/master/google/cloud/forseti/scanner/scanners/config_validator_util/validator_pb2.py)
-and [validator_pb2_grpc.py](https://github.com/forseti-security/forseti-security/blob/master/google/cloud/forseti/scanner/scanners/config_validator_util/validator_pb2_grpc.py). 
-  
-  ```
-   git clone https://github.com/forseti-security/config-validator.git
-  ```
+Run the following commands to generate the protos:
 
   ```
+  export CV_VERSION=master
+  git clone --branch $CV_VERSION https://github.com/forseti-security/config-validator.git
   cd config-validator
-  ```
- 
-  ```
   make build
-  ```
-  
-  ```
   make pyproto
   ```
 
-- Compare the protos generated in the above step with  [validator_pb2.py](https://github.com/forseti-security/forseti-security/blob/master/google/cloud/forseti/scanner/scanners/config_validator_util/validator_pb2.py)
-and [validator_pb2_grpc.py](https://github.com/forseti-security/forseti-security/blob/master/google/cloud/forseti/scanner/scanners/config_validator_util/validator_pb2_grpc.py) to determine
-if protos have changed.
+The Python proto files will be created in the `build-grpc` directory of the Config Validator repo. Copy these files to 
+the [google/cloud/forseti/scanner/scanners/config_validator_util directory](https://github.com/forseti-security/forseti-security/blob/master/google/cloud/forseti/scanner/scanners/config_validator_util) 
+in the Forseti repo.
 
-**Note:**
-- Changes to the Config Validator Scanner may be required if protos have changed.
-- Versions of Config Validator newer than the default value included use OPA 
-0.17.x, which is not compatible with some of the policies. Default 
-values can be found [here](https://github.com/forseti-security/terraform-google-forseti#inputs).
-Please reach out to the [Forseti Security Team](https://forsetisecurity.org/docs/latest/use/get-help.html) 
-to see if the specific Config Validator image/tag that you want to you use is 
-supported.
+One of the first lines of the [grpc proto](https://github.com/forseti-security/forseti-security/blob/master/google/cloud/forseti/scanner/scanners/config_validator_util/validator_pb2_grpc.py)
+will need to be updated. Search for `import validator_pb2 as validator__pb2` and replace it with 
+`from . import validator_pb2 as validator__pb2`.
+
+## **Policy Library**
+
+Newer versions of Config Validator have more schema validation and might target different versions of Open Policy Agent.
+Before deploying a new version of Config Validator with Forseti, ensure that your Policy Library is compatible. It is 
+recommended to get the latest versions of the [Policy Library templates](https://github.com/forseti-security/policy-library/tree/master/policies/templates).
+Constraints referencing these templates should still be compatible.
+
+## **Testing**
+
+To test Forseti after the Config Validator protos have been added, first run the unit tests:
+
+    ```
+    make docker_test_unit
+    ```
+
+If all tests pass, then [run Forseti locally]({% link _docs/latest/develop/dev/setup.md %})
+along with Config Validator. It's recommended to run Forseti in an IDE (like PyCharm) for debugging and troubleshooting 
+purposes. Config Validator can be run with Docker; enter the following commands from the Config Validator cloned repo:
+    
+    ```
+    export POLICY_LIBRARY_DIR=/path/to/policy/library
+    make docker_run
+    ```
+
+Ensure the Forseti server configuration referenced by PyCharm has the following settings:
+
+    - Enable the Config Validator scanner
+    - Disable the [verify policy library feature](https://github.com/forseti-security/terraform-google-forseti/blob/master/modules/server_config/templates/configs/forseti_conf_server.yaml.tpl#L240)
+
+When Forseti and Config Validator are both running, run a scan with Forseti and verify there are no errors. Check the 
+CloudSQL database to confirm that the violations produced by the scan are correct.
+
+## **Commit Changes**
+
+Create a feature branch and submit a PR to the Forseti repo for the updated protos, along with any other changes. The
+Forseti automated tests will run to confirm all parts of Forseti are still working correctly, including Config 
+Validator.


### PR DESCRIPTION
Update Config Validator docs to include more information setting up CV with Terraform, the Policy Library options, and how to upgrade the CV version used by Forseti.

Resolves #3806