### PR TITLE
Enabling enforcer updates between denied <-> allowed FW rules

### DIFF
--- a/google/cloud/forseti/common/gcp_api/compute.py
+++ b/google/cloud/forseti/common/gcp_api/compute.py
@@ -1030,8 +1030,8 @@ class ComputeClient(object):
             json.dumps(rule, sort_keys=True), results)
         return results
 
-    def replace_firewall_rule(self, project_id, rule, delete_uuid = None,
-                              insert_uuid = None, blocking=True, retry_count=0,
+    def replace_firewall_rule(self, project_id, rule, delete_uuid=None,
+                              insert_uuid=None, blocking=True, retry_count=0,
                               timeout=0):
         """Replace a firewall rule using delete & insert.
 

--- a/google/cloud/forseti/common/gcp_api/compute.py
+++ b/google/cloud/forseti/common/gcp_api/compute.py
@@ -1030,6 +1030,81 @@ class ComputeClient(object):
             json.dumps(rule, sort_keys=True), results)
         return results
 
+    def replace_firewall_rule(self,
+        project_id,
+        rule,
+        delete_uuid = None,
+        insert_uuid = None,
+        blocking=True,
+        retry_count=0,
+        timeout=0):
+        """Replace a firewall rule using delete & insert.
+
+            Args:
+              project_id (str): The project id.
+              rule (dict): The firewall rule dict to insert.
+              uuid (str): An optional UUID to identify this request. If the same
+                request is resent to the API, it will ignore the additional
+                requests. If uuid is not set, one will be generated for the request.
+              blocking (bool): Required to be true, don't return until the async
+                operation completes on the backend or timeout seconds pass.
+              retry_count (int): If greater than 0, retry on operation timeout.
+              timeout (float): If greater than 0 and blocking is True, then raise an
+                exception if timeout seconds pass before the operation completes.
+
+            Returns:pyspanner.py:1528
+                dict: Global Operation status and info.
+                https://cloud.google.com/compute/docs/reference/latest/globalOperations/get
+
+            Raises:
+                ApiNotEnabledError: The api is not enabled.
+                ApiExecutionError: The api returned an error.
+                KeyError: The 'name' key is missing from the rule dict.
+                OperationTimeoutError: Raised if the operation times out.
+            """
+        if not blocking:
+            raise ValueError('blocking must be true.')
+        repository = self.repository.firewalls
+        if not delete_uuid:
+            delete_uuid = uuid4()
+        if not insert_uuid:
+            insert_uuid = uuid4()
+
+        try:
+            results = repository.delete(
+                project_id, target=rule['name'], requestId=delete_uuid)
+
+            self.wait_for_completion(project_id, results, timeout)
+
+            results = repository.insert(project_id, data=rule, requestId=insert_uuid)
+
+            results = self.wait_for_completion(project_id, results, timeout)
+        except (errors.HttpError, HttpLib2Error) as e:
+            LOGGER.error('Error replacing firewall rule %s: %s', rule['name'], e)
+            api_not_enabled, details = _api_not_enabled(e)
+            if api_not_enabled:
+                raise api_errors.ApiNotEnabledError(details, e)
+            raise api_errors.ApiExecutionError(project_id, e)
+        except api_errors.OperationTimeoutError as e:
+            LOGGER.warning('Timeout replacing firewall rule %s: %s', rule['name'], e)
+            if retry_count:
+                retry_count -= 1
+                return self.replace_firewall_rule(project_id=project_id,
+                                                  rule=rule,
+                                                  insert_uuid=insert_uuid,
+                                                  delete_uuid=delete_uuid,
+                                                  blocking=blocking,
+                                                  retry_count=retry_count,
+                                                  timeout=timeout)
+            else:
+                raise
+
+        LOGGER.info(
+            'Replacing firewall rule %s on project %s. Rule: %s, '
+            'Result: %s', rule['name'], project_id,
+            json.dumps(rule, sort_keys=True), results)
+        return results
+
     def get_forwarding_rules(self, project_id, region=None):
         """Get the forwarding rules for a project.
 

--- a/google/cloud/forseti/common/gcp_api/compute.py
+++ b/google/cloud/forseti/common/gcp_api/compute.py
@@ -1030,14 +1030,9 @@ class ComputeClient(object):
             json.dumps(rule, sort_keys=True), results)
         return results
 
-    def replace_firewall_rule(self,
-        project_id,
-        rule,
-        delete_uuid = None,
-        insert_uuid = None,
-        blocking=True,
-        retry_count=0,
-        timeout=0):
+    def replace_firewall_rule(self, project_id, rule, delete_uuid = None,
+                              insert_uuid = None, blocking=True, retry_count=0,
+                              timeout=0):
         """Replace a firewall rule using delete & insert.
 
             Args:

--- a/google/cloud/forseti/enforcer/gce_firewall_enforcer.py
+++ b/google/cloud/forseti/enforcer/gce_firewall_enforcer.py
@@ -189,9 +189,9 @@ def _rule_update_can_patch(rule_from, rule_to):
     if not rule_to or not rule_from:
         raise ValueError('from and to must both exist for checking replace vs patch.')
     if 'allowed' in rule_from and 'denied' in rule_to:
-        return False # Patch fails to update allowed -> denied
+        return False  # Patch fails to update allowed -> denied
     if 'denied' in rule_from and 'allowed' in rule_to:
-        return False # Patch fails to update denied -> allowed
+        return False  # Patch fails to update denied -> allowed
     return True
 
 
@@ -956,7 +956,7 @@ class FirewallEnforcer(object):
             raise FirewallEnforcementUpdateFailedError(
                 'Firewall enforcement failed while deleting rules for '
                 'project {}. The following errors were encountered: {}'
-                    .format(self.project, change_errors))
+              .format(self.project, change_errors))
         return len(successes)
 
     def _replace_rules(self, rules):
@@ -969,10 +969,8 @@ class FirewallEnforcer(object):
             raise FirewallEnforcementUpdateFailedError(
                 'Firewall enforcement failed while deleting rules for '
                 'project {}. The following errors were encountered: {}'
-                    .format(self.project, change_errors))
+              .format(self.project, change_errors))
         return len(successes)
-
-        return change_count
 
     def _apply_change(self, firewall_function, rules):
         """Modify the firewall using the passed in function and rules.

--- a/google/cloud/forseti/enforcer/gce_firewall_enforcer.py
+++ b/google/cloud/forseti/enforcer/gce_firewall_enforcer.py
@@ -185,6 +185,16 @@ def filter_rules_by_network(rules, network):
     return filtered_rules
 
 
+def _rule_update_can_patch(rule_from, rule_to):
+    if not rule_to or not rule_from:
+        raise ValueError('from and to must both exist for checking replace vs patch.')
+    if 'allow' in rule_from and 'allow' not in rule_to:
+        return False # Patch fails to update denied -> denied
+    if 'denied' in rule_from and 'denied' not in rule_to:
+        return False # Patch fails to update denied -> allowed
+    return False
+
+
 class FirewallRules(object):
     """A collection of validated firewall rules."""
 
@@ -923,16 +933,44 @@ class FirewallEnforcer(object):
                 self.expected_rules.rules[rule_name]
                 for rule_name in self._rules_to_update
             ], network)
-            patch_function = self.compute_client.patch_firewall_rule
-            (successes, failures, change_errors) = self._apply_change(
-                patch_function, rules)
-            self._updated_rules.extend(successes)
-            change_count += len(successes)
-            if failures:
-                raise FirewallEnforcementUpdateFailedError(
-                    'Firewall enforcement failed while deleting rules for '
-                    'project {}. The following errors were encountered: {}'
+            rules_to_patch = []
+            rules_to_replace = []
+            for rule in rules:
+                if _rule_update_can_patch(self.current_rules.rules[rule['name']], rule):
+                    rules_to_patch.append(rule)
+                else:
+                    rules_to_replace.append(rule)
+            if rules_to_patch:
+                change_count += self._patch_rules(rules_to_patch)
+            if rules_to_replace:
+                change_count += self._replace_rules(rules_to_replace)
+        return change_count
+
+    def _patch_rules(self, rules):
+        LOGGER.info('Patching rules: %s', ', '.join(rule['name'] for rule in rules))
+        patch_function = self.compute_client.patch_firewall_rule
+        (successes, failures, change_errors) = self._apply_change(
+            patch_function, rules)
+        self._updated_rules.extend(successes)
+        if failures:
+            raise FirewallEnforcementUpdateFailedError(
+                'Firewall enforcement failed while deleting rules for '
+                'project {}. The following errors were encountered: {}'
                     .format(self.project, change_errors))
+        return len(successes)
+
+    def _replace_rules(self, rules):
+        LOGGER.info('Replacing rules: %s', ', '.join(rule['name'] for rule in rules))
+        patch_function = self.compute_client.replace_firewall_rule
+        (successes, failures, change_errors) = self._apply_change(
+            patch_function, rules)
+        self._updated_rules.extend(successes)
+        if failures:
+            raise FirewallEnforcementUpdateFailedError(
+                'Firewall enforcement failed while deleting rules for '
+                'project {}. The following errors were encountered: {}'
+                    .format(self.project, change_errors))
+        return len(successes)
 
         return change_count
 

--- a/google/cloud/forseti/enforcer/gce_firewall_enforcer.py
+++ b/google/cloud/forseti/enforcer/gce_firewall_enforcer.py
@@ -956,7 +956,7 @@ class FirewallEnforcer(object):
             raise FirewallEnforcementUpdateFailedError(
                 'Firewall enforcement failed while deleting rules for '
                 'project {}. The following errors were encountered: {}'
-              .format(self.project, change_errors))
+                .format(self.project, change_errors))
         return len(successes)
 
     def _replace_rules(self, rules):
@@ -969,7 +969,7 @@ class FirewallEnforcer(object):
             raise FirewallEnforcementUpdateFailedError(
                 'Firewall enforcement failed while deleting rules for '
                 'project {}. The following errors were encountered: {}'
-              .format(self.project, change_errors))
+                .format(self.project, change_errors))
         return len(successes)
 
     def _apply_change(self, firewall_function, rules):

--- a/google/cloud/forseti/enforcer/gce_firewall_enforcer.py
+++ b/google/cloud/forseti/enforcer/gce_firewall_enforcer.py
@@ -188,11 +188,11 @@ def filter_rules_by_network(rules, network):
 def _rule_update_can_patch(rule_from, rule_to):
     if not rule_to or not rule_from:
         raise ValueError('from and to must both exist for checking replace vs patch.')
-    if 'allow' in rule_from and 'allow' not in rule_to:
-        return False # Patch fails to update denied -> denied
-    if 'denied' in rule_from and 'denied' not in rule_to:
+    if 'allowed' in rule_from and 'denied' in rule_to:
+        return False # Patch fails to update allowed -> denied
+    if 'denied' in rule_from and 'allowed' in rule_to:
         return False # Patch fails to update denied -> allowed
-    return False
+    return True
 
 
 class FirewallRules(object):

--- a/tests/common/gcp_api/compute_test.py
+++ b/tests/common/gcp_api/compute_test.py
@@ -270,6 +270,7 @@ class ComputeTest(unittest_utils.ForsetiTestCase):
             self.gce_api_client.delete_firewall_rule(
                 self.project_id, rule=fake_compute.FAKE_FIREWALL_RULE)
 
+    @parameterized.parameterized.expand(ERROR_TEST_CASES)
     def test_insert_firewall_rule_errors(self, name, response, status,
                                        expected_exception):
         """Verify error conditions for insert firewall rule."""

--- a/tests/common/gcp_api/compute_test.py
+++ b/tests/common/gcp_api/compute_test.py
@@ -270,13 +270,30 @@ class ComputeTest(unittest_utils.ForsetiTestCase):
             self.gce_api_client.delete_firewall_rule(
                 self.project_id, rule=fake_compute.FAKE_FIREWALL_RULE)
 
-    @parameterized.parameterized.expand(ERROR_TEST_CASES)
     def test_insert_firewall_rule_errors(self, name, response, status,
                                        expected_exception):
         """Verify error conditions for insert firewall rule."""
         http_mocks.mock_http_response(response, status)
         with self.assertRaises(expected_exception):
             self.gce_api_client.insert_firewall_rule(
+                self.project_id, rule=fake_compute.FAKE_FIREWALL_RULE)
+
+    @parameterized.parameterized.expand(ERROR_TEST_CASES)
+    def test_patch_firewall_rule_errors(self, name, response, status,
+        expected_exception):
+        """Verify error conditions for patching firewall rule."""
+        http_mocks.mock_http_response(response, status)
+        with self.assertRaises(expected_exception):
+            self.gce_api_client.patch_firewall_rule(
+                self.project_id, rule=fake_compute.FAKE_FIREWALL_RULE)
+
+    @parameterized.parameterized.expand(ERROR_TEST_CASES)
+    def test_replace_firewall_rule_errors(self, name, response, status,
+        expected_exception):
+        """Verify error conditions for replacing firewall rule."""
+        http_mocks.mock_http_response(response, status)
+        with self.assertRaises(expected_exception):
+            self.gce_api_client.replace_firewall_rule(
                 self.project_id, rule=fake_compute.FAKE_FIREWALL_RULE)
 
     @parameterized.parameterized.expand(ERROR_TEST_CASES)

--- a/tests/enforcer/gce_firewall_enforcer_test.py
+++ b/tests/enforcer/gce_firewall_enforcer_test.py
@@ -577,6 +577,32 @@ class FirewallEnforcerTest(constants.EnforcerTestCase):
         self.assertSameStructure([expected_updated_rule],
                                  self.enforcer.get_updated_rules())
 
+    def test_apply_firewall_denied_to_allowed(self):
+        """Validate apply_firewall works with replacing (delete & insert) rules.
+
+        Setup:
+          Set EXPECTED_FIREWALL_RULES as the enforced policy.
+
+          Modify one of the firewall rules to change allowed to be denied.
+          This registers as an update, but cannot use the patch method.
+
+        Expected Results:
+          * firewall will register as an update (as they share a name)
+          * updated rule will update to match the expected rule (allowed)
+        """
+        self.expected_rules.rules = copy.deepcopy(constants.EXPECTED_FIREWALL_RULES)
+        self.current_rules.rules = copy.deepcopy(constants.EXPECTED_FIREWALL_RULES)
+
+        # update current rule from allowed to denied
+        # This registers as an update since they share the same name, but this
+        # type of update will fail if attempting to use the patch method.
+        self.current_rules.rules['test-network-allow-public-0']['denied'] = self.current_rules.rules['test-network-allow-public-0'].pop('allowed')
+
+        _ = self.enforcer.apply_firewall()
+
+        self.assertSameStructure([constants.EXPECTED_FIREWALL_RULES['test-network-allow-public-0']],
+                      self.enforcer.get_updated_rules())
+
     def test_apply_firewall_prechange_callback_false(self):
         """Prechange callback that returns False stops changes from being made.
 

--- a/tests/enforcer/gce_firewall_enforcer_test.py
+++ b/tests/enforcer/gce_firewall_enforcer_test.py
@@ -845,14 +845,15 @@ class FirewallEnforcerTest(constants.EnforcerTestCase):
         """Validate apply_change works with no errors."""
         delete_function = self.gce_api_client.delete_firewall_rule
         insert_function = self.gce_api_client.insert_firewall_rule
-        update_function = self.gce_api_client.patch_firewall_rule
+        patch_function = self.gce_api_client.patch_firewall_rule
+        replace_function = self.gce_api_client.replace_firewall_rule
 
         test_rules = [
             copy.deepcopy(constants.EXPECTED_FIREWALL_RULES[
                 'test-network-allow-internal-0'])
         ]
 
-        for function in [delete_function, insert_function, update_function]:
+        for function in [delete_function, insert_function, patch_function, replace_function]:
             (successes, failures, change_errors) = self.enforcer._apply_change(
                 function, test_rules)
             self.assertSameStructure(test_rules, successes)


### PR DESCRIPTION
Currently enforcer will fail to update a rule from 'allowed' <-> 'denied' with the following error

```
Error changing firewall rule asdf-some-fw-rule-name-asdf for project bap-iap: GCP API Error: unable to get bap-iap from GCP:
<HttpError 400 when requesting https://compute.googleapis.com/compute/v1/projects/bap-iap/global/firewalls/asdf-some-fw-rule-name-asdf?requestId=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee&alt=json returned "Invalid value for field 'resource.allowed[0]': ''. Should not specify both allowed and denied in the same time.">
{
  "error": {
    "code": 400,
    "message": "Invalid value for field 'resource.allowed[0]': ''. Should not specify both allowed and denied in the same time.",
    "errors": [
      {
        "message": "Invalid value for field 'resource.allowed[0]': ''. Should not specify both allowed and denied in the same time.",
        "domain": "global",
        "reason": "invalid",
        "debugInfo": "java.lang.Exception\n\tat com.google.cloud.control.common.publicerrors.PublicErrorProtoUtils.newErrorBuilder(PublicErrorProtoUtils.java:1617)\n\tat com.google.cloud.control.common.publicerrors.PublicErrorProtoUtils.createInvalidFieldValue(PublicErrorProtoUtils.java:764)\n\tat com.google.cloud.control.common.publicerrors.PublicErrorProtoUtils.createInvalidFieldValue(PublicErrorProtoUtils.java:737)\n\tat com.google.cloud.cluster.manager.networking.services.firewall.MixerFirewallInputValidator.createAllowAndDenyInOneRequestError(MixerFirewallInputValidator.java:543)\n\tat com.google.cloud.cluster.manager.networking.services.firewall.MixerFirewallInputValidator.verifyRules(MixerFirewallInputValidator.java:406)\n\tat com.google.cloud.cluster.manager.networking.services.firewall.MixerFirewallInputValidator.verifyFirewallInput(MixerFirewallInputValidator.java:239)\n\tat com.google.cloud.cluster.manager.networking.services.firewall.FirewallsServiceUpdateAction$Handler.prepareMutationFlow(FirewallsServiceUpdateAction.java:297)\n\tat com.google.cloud.cluster.manager.networking.services.firewall.FirewallsServiceUpdateAction$Handler.prepareMutationFlow(FirewallsServiceUpdateAction.java:160)\n\tat com.google.cloud.control.frontend.action.ResourceMixerMutationActionExecutor$InnerHandler.prepareMutationFlowForProvider(ResourceMixerMutationActionExecutor.java:483)\n\tat com.google.cloud.control.frontend.action.ResourceMixerMutationActionExecutor$InnerHandler.prepareMutationFlow(ResourceMixerMutationActionExecutor.java:408)\n\tat com.google.cloud.control.frontend.action.ResourceMixerMutationActionExecutor$InnerHandler.prepareMutationFlow(ResourceMixerMutationActionExecutor.java:365)\n\tat com.google.cloud.control.frontend.action.MixerMutationActionExecutor$InnerHandler.runAttempt(MixerMutationActionExecutor.java:809)\n\tat com.google.cloud.control.frontend.action.MixerMutationActionExecutor$InnerHandler.runAttempt(MixerMutationActionExecutor.java:489)\n\tat com.google.cloud.cluster.metastore.RetryingMetastoreTransactionExecutor$1.runAttempt(RetryingMetastoreTransactionExecutor.java:75)\n\tat com.google.cloud.cluster.metastore.MetastoreRetryLoop.runHandler(MetastoreRetryLoop.java:454)\n\t...Stack trace is shortened.\n"
      }
    ]
  }
}
```

These rules will share the same name, so enforcer attempts to use 'patch' to update these types of rule changes. I tinkered around with API/gcloud/webUI calls and it appears that patch/update will both fail for this type of update. The only option is to delete and insert the rule to make this change.

I tried to put this distinction close to the compute API calls, as the rules classified as 'insert/update/delete' is exported and can be depended on by other systems. This changes doesn't modify the format of the exported results.

The '_rule_update_can_patch' is intended to directly service the needs of this change, but also indicate an area that could be expanded if we discover more update patterns that will need this replacement style.

Considered failure conditions
 - general failure after insert. Final error result will be handled like other API errors, if the delete succeeded then the next iteration/retry of enforcer will classify this rule as a insert, not a replace and will fall under the existing feature set
 - timeout failures
   + delete/insert times out, but actually succeeds. The request_id is re-used for retries so the delete should just skip.




Thanks for opening a Pull Request!

Here's a handy checklist to ensure your PR goes smoothly.

- [X] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [X] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [X] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [X] My PR has been functionally tested.
- [X] All of the [tests](https://forsetisecurity.org/docs/latest/develop/dev/testing.html) pass.
- [X] I have submitted a corresponding PR for documentation in the `forsetisecurity.org-dev branch` and included this on this PR (if applicable).
- [X] My documentation has been functionally tested and used (if applicable).
- [X] I have submitted a corresponding PR in the [Forseti Terraform module](https://github.com/forseti-security/terraform-google-forseti) (if applicable).

These guidelines and more can be found in our [contributing guidelines](https://github.com/forseti-security/forseti-security/blob/dev/.github/CONTRIBUTING.md).
