### PR TITLE
Fix document links (for master branch)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -95,7 +95,7 @@ To submit a pull request for Forseti, follow the process below:
      - You should write applicable unit tests for your changes, especially for 
        changes involving substantial logic.
      - Learn how to
-       [run the tests](https://forsetisecurity.org/docs/latest/develop/dev/testing.html).
+       [run the tests](https://forsetisecurity.org/docs/latest/develop/test/index.html).
 
   1. Commit your changes and push them to your development branch:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Here's a handy checklist to ensure your PR goes smoothly.
 - [ ] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
 - [ ] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
 - [ ] My PR has been functionally tested.
-- [ ] All of the [tests](https://forsetisecurity.org/docs/latest/develop/dev/testing.html) pass.
+- [ ] All of the [tests](https://forsetisecurity.org/docs/latest/develop/test/index.html) pass.
 - [ ] I have submitted a corresponding PR for documentation in the `forsetisecurity.org-dev branch` and included this on this PR (if applicable).
 - [ ] My documentation has been functionally tested and used (if applicable).
 - [ ] I have submitted a corresponding PR in the [Forseti Terraform module](https://github.com/forseti-security/terraform-google-forseti) (if applicable).


### PR DESCRIPTION
I found document url links are broken(tombstone-pages) and fixed them.
[tombstone-pages](https://github.com/forseti-security/forseti-security/tree/forsetisecurity.org-dev#tombstone-pages) works well for external sites, but unnecessary for internal links.

----
Here's a handy checklist to ensure your PR goes smoothly.

- [x] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [x] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [x] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [x] My PR has been functionally tested.
- [x] All of the [tests](https://forsetisecurity.org/docs/latest/develop/dev/testing.html) pass.
- [x] My documentation has been functionally tested and used (if applicable).

[not applicable]
- [ ] I have submitted a corresponding PR for documentation in the `forsetisecurity.org-dev branch` and included this on this PR (if applicable).
- [ ] I have submitted a corresponding PR in the [Forseti Terraform module](https://github.com/forseti-security/terraform-google-forseti) (if applicable).

These guidelines and more can be found in our [contributing guidelines](https://github.com/forseti-security/forseti-security/blob/dev/.github/CONTRIBUTING.md).
