### PR TITLE
Fix document link ( for forsetisecurity.org-dev branch )

### DIFF
--- a/_docs/_latest/configure/general/non-org-root.md
+++ b/_docs/_latest/configure/general/non-org-root.md
@@ -20,7 +20,7 @@ of resources, but Explain will not be supported.
 
 ## How to Install
 
-Run the Forseti [Installer]({% link _docs/latest/setup/install.md %}).
+Run the Forseti [Installer]({% link _docs/latest/setup/intall/index.md %}).
 
 By default, the installer will try to assign org-level roles. If you are not
 an Org Admin, there will be errors, but you can safely disregard, as you will

--- a/_docs/_latest/configure/notifier/index.md
+++ b/_docs/_latest/configure/notifier/index.md
@@ -232,7 +232,7 @@ Cloud SCC API is now Generally Available (GA). Please see the steps below to
 setup and configure.
 
 #### Prerequisites
-1. [Install]({% link _docs/latest/setup/install.md %})
+1. [Install]({% link _docs/latest/setup/intall/index.md %})
 or [upgrade]({% link _docs/latest/setup/upgrade.md %}) Forseti to version 2.14+. 
 1. The person performing the onboarding needs the following org-level IAM roles:
 - `Organization Admin`

--- a/_docs/_latest/develop/dev/inventory.md
+++ b/_docs/_latest/develop/dev/inventory.md
@@ -205,4 +205,4 @@ resources are accounted for in the inventory.
 
 Now that the new Inventory resource will be included in the test data, the
 `test_crawling_to_memory_storage` test can be run by following the
-[Testing instructions](https://forsetisecurity.org/docs/latest/develop/dev/testing.html).
+[Testing instructions](https://forsetisecurity.org/docs/latest/develop/test/index.html).

--- a/_faq/installation_and_deployment/which-deployment.md
+++ b/_faq/installation_and_deployment/which-deployment.md
@@ -5,9 +5,9 @@ order: 1
 {::options auto_ids="false" /}
 
 * To set up Forseti automatically in GCP with sane defaults, use the
-[installer]({% link _docs/latest/setup/install.md %}).
+[installer]({% link _docs/latest/setup/intall/index.md %}).
 * To set up Forseti for development or local use, follow the
 [Development Environment Setup guide]({% link _docs/latest/develop/dev/setup.md %}).
 * To set up Forseti in GCP with more flexibility in configuration, use the
-[installer]({% link _docs/latest/setup/install.md %}) and then
+[installer]({% link _docs/latest/setup/intall/index.md %}) and then
 [configure features]({% link _docs/latest/configure/index.md %}).

--- a/_news/2018-06-11-forseti-2.0-launch.md
+++ b/_news/2018-06-11-forseti-2.0-launch.md
@@ -36,7 +36,7 @@ If you'd like to upgrade from version 1.0, see the
 
 
 If you're new to Forseti and want to get started, see the
-[Forseti v2 installation guide]({% link _docs/latest/setup/install.md %}).
+[Forseti v2 installation guide]({% link _docs/latest/setup/intall/index.md %}).
 
 As always, we are eager for you to get involved and add your ideas to take
 Forseti to even greater heights!


### PR DESCRIPTION
I found document url links are broken(tombstone-pages) and fixed them.
[tombstone-pages](https://github.com/forseti-security/forseti-security/tree/forsetisecurity.org-dev#tombstone-pages) works well for external sites, but unnecessary for internal links.