### PR TITLE
Add networks to ProjectResult proto

### DIFF
--- a/google/cloud/forseti/enforcer/enforcer_log.proto
+++ b/google/cloud/forseti/enforcer/enforcer_log.proto
@@ -99,6 +99,9 @@ message ProjectResult {
   optional string status_reason = 7;
 
   optional GceFirewallEnforcementResult gce_firewall_enforcement = 8;
+
+  // Names of the networks that were enforced
+  repeated string networks = 9;
 }
 
 message EnforcerLog {

--- a/google/cloud/forseti/enforcer/project_enforcer.py
+++ b/google/cloud/forseti/enforcer/project_enforcer.py
@@ -137,6 +137,7 @@ class ProjectEnforcer(object):
                 if not networks:
                     self._set_error_status('no networks found for project')
                     return self.result
+            self.result.networks.extend(networks)
 
             expected_rules = self._get_expected_rules(networks,
                                                       firewall_policy)

--- a/tests/enforcer/project_enforcer_test.py
+++ b/tests/enforcer/project_enforcer_test.py
@@ -43,7 +43,8 @@ class ProjectEnforcerTest(constants.EnforcerTestCase):
 
         self.expected_proto = enforcer_log_pb2.ProjectResult(
             timestamp_sec=constants.MOCK_MICROTIMESTAMP,
-            project_id=self.project)
+            project_id=self.project,
+            networks=['test-network'])
 
         self.expected_rules = copy.deepcopy(
             list(constants.EXPECTED_FIREWALL_RULES.values()))
@@ -667,6 +668,7 @@ class ProjectEnforcerTest(constants.EnforcerTestCase):
         self.expected_proto.status_reason = (
                 'error getting current networks from API: <HttpError 403 '
                 '"Failed">')
+        self.expected_proto.ClearField('networks')
 
         self.validate_results(self.expected_proto, result)
         self.assertTrue(mock_logger.exception.called)
@@ -757,6 +759,7 @@ class ProjectEnforcerTest(constants.EnforcerTestCase):
         result = self.enforcer.enforce_firewall_policy(self.policy)
 
         self.expected_proto.status = project_enforcer.STATUS_DELETED
+        self.expected_proto.ClearField('networks')
 
         # Match first part of error reason string
         self.assertStartsWith(result.status_reason,

--- a/tests/enforcer/testing_constants.py
+++ b/tests/enforcer/testing_constants.py
@@ -572,6 +572,7 @@ SAMPLE_ENFORCER_PROJECTRESULTS_ASCIIPB = """
     rules_modified_count: 7
     all_rules_changed: true
   }
+  networks: "test-network"
 """
 
 


### PR DESCRIPTION
This PR adds a new repeated string `networks` field to the ProjectResult proto. This is useful in cases where you want to look back through the ProjectResult protos to see what networks Forseti was acting on when they were generated.

Thanks for opening a Pull Request!

Here's a handy checklist to ensure your PR goes smoothly.

- [x] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [x] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [ ] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [x] My PR has been functionally tested.
- [x] All of the [tests](https://forsetisecurity.org/docs/latest/develop/dev/testing.html) pass.
- [ ] I have submitted a corresponding PR for documentation in the `forsetisecurity.org-dev branch` and included this on this PR (if applicable).
- [ ] My documentation has been functionally tested and used (if applicable).
- [ ] I have submitted a corresponding PR in the [Forseti Terraform module](https://github.com/forseti-security/terraform-google-forseti) (if applicable).

These guidelines and more can be found in our [contributing guidelines](https://github.com/forseti-security/forseti-security/blob/dev/.github/CONTRIBUTING.md).
