### PR TITLE
forseti cron script fails because python do not have an alias

### DIFF
--- a/install/gcp/scripts/run_forseti.sh
+++ b/install/gcp/scripts/run_forseti.sh
@@ -61,7 +61,7 @@ echo "Running Forseti inventory."
 forseti inventory create --import_as ${MODEL_NAME}
 echo "Finished running Forseti inventory."
 
-GET_MODEL_STATUS="forseti model get ${MODEL_NAME} | python -c \"import sys, json; print json.load(sys.stdin)['status']\""
+GET_MODEL_STATUS="forseti model get ${MODEL_NAME} | python -c \"import sys, json; print(json.load(sys.stdin)['status'])\""
 MODEL_STATUS=`eval $GET_MODEL_STATUS`
 
 if ([ "$MODEL_STATUS" != "SUCCESS" ] && [ "$MODEL_STATUS" != "PARTIAL_SUCCESS" ])

--- a/install/gcp/scripts/run_forseti.sh
+++ b/install/gcp/scripts/run_forseti.sh
@@ -61,7 +61,7 @@ echo "Running Forseti inventory."
 forseti inventory create --import_as ${MODEL_NAME}
 echo "Finished running Forseti inventory."
 
-GET_MODEL_STATUS="forseti model get ${MODEL_NAME} | python -c \"import sys, json; print(json.load(sys.stdin)['status'])\""
+GET_MODEL_STATUS="forseti model get ${MODEL_NAME} | python3 -c \"import sys, json; print(json.load(sys.stdin)['status'])\""
 MODEL_STATUS=`eval $GET_MODEL_STATUS`
 
 if ([ "$MODEL_STATUS" != "SUCCESS" ] && [ "$MODEL_STATUS" != "PARTIAL_SUCCESS" ])


### PR DESCRIPTION
## Condition
- forseti version: v2.25.2
- module: [run_forseti.sh](https://github.com/forseti-security/forseti-security/blob/release-2.25.2/install/gcp/scripts/run_forseti.sh#L64) ( cron script )
- creating method: using the terraform module (create on GCE)

## Issue
After creating the server with terraform, python3 is installed but no alias is set for python.
This causes an error when running [the python command in run_forseti.sh](https://github.com/forseti-security/forseti-security/blob/release-2.25.2/install/gcp/scripts/run_forseti.sh#L64).
```
$ forseti model get ${MODEL_NAME} | python -c \"import sys, json; print json.load(sys.stdin)['status']\"

python: command not found
```
In addition,  this python command uses the python2 syntax, python3 `()` for print method.


In the docker environment, [docker_entrypoint.sh](https://github.com/forseti-security/forseti-security/blob/release-2.25.2/install/scripts/docker_entrypoint.sh#L155) uses python3 directly and uses python3 syntax.
so I fixed run_forseti.sh same as docker_entrypoint.sh.
