### PR TITLE
Updating the csv_writer module to remove the unicodecsv dependency.

### DIFF
--- a/google/cloud/forseti/common/data_access/csv_writer.py
+++ b/google/cloud/forseti/common/data_access/csv_writer.py
@@ -14,11 +14,10 @@
 
 """Writes the csv files for upload to Cloud SQL."""
 from contextlib import contextmanager
+import csv
 import json
 import os
 import tempfile
-
-import unicodecsv as csv
 
 from google.cloud.forseti.common.data_access.errors import CSVFileError
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ REQUIRED_PACKAGES = [
     'requests[security]==2.21.0',
     'sendgrid==5.6.0',
     'simple-crypt==4.1.7',
-    'unicodecsv==0.14.1',
     # Setup related.
     'grpcio>=1.22.0',
     'grpcio-tools>=1.22.0',


### PR DESCRIPTION
Python 3 has native unicode support in its builtin csv module.
