### PR TITLE
Modify API clients to pass cache_discovery and cache parameters to BaseRepositoryClient from global_configs

### DIFF
--- a/google/cloud/forseti/common/gcp_api/_base_repository.py
+++ b/google/cloud/forseti/common/gcp_api/_base_repository.py
@@ -71,7 +71,7 @@ DISCOVERY_DOCS_BASE_DIR = os.path.join(os.path.abspath(
        wait_exponential_multiplier=1000, wait_exponential_max=10000,
        stop_max_attempt_number=5)
 def _create_service_api(credentials, service_name, version, is_private_api,
-                        developer_key=None, cache_discovery=False,
+                        developer_key=None, cache_discovery=False, cache=None,
                         use_versioned_discovery_doc=False):
     """Builds and returns a cloud API service object.
 
@@ -85,6 +85,9 @@ def _create_service_api(credentials, service_name, version, is_private_api,
             associated with the API call, most API services do not require
             this to be set.
         cache_discovery (bool): Whether or not to cache the discovery doc.
+        cache (googleapiclient.discovery_cache.base.Cache): instance of a class
+            that can cache API discovery documents. If None, googleapiclient
+            will attempt to choose a default.
         use_versioned_discovery_doc (bool): When set to true, will use the
             discovery doc with the version suffix in the filename.
 
@@ -118,6 +121,7 @@ def _create_service_api(credentials, service_name, version, is_private_api,
         'credentials': credentials}
     if SUPPORT_DISCOVERY_CACHE:
         discovery_kwargs['cache_discovery'] = cache_discovery
+        discovery_kwargs['cache'] = cache
 
     return discovery.build(**discovery_kwargs)
 
@@ -155,6 +159,8 @@ class BaseRepositoryClient(object):
                  use_rate_limiter=False,
                  read_only=False,
                  use_versioned_discovery_doc=False,
+                 cache_discovery=False,
+                 cache=None,
                  **kwargs):
         """Constructor.
 
@@ -172,6 +178,11 @@ class BaseRepositoryClient(object):
                 would modify a resource within the repository.
             use_versioned_discovery_doc (bool): When set to true, will use the
                 discovery doc with the version suffix in the filename.
+            cache_discovery (bool): When set to true, googleapiclient will cache
+                HTTP requests to API discovery endpoints.
+            cache (googleapiclient.discovery_cache.base.Cache): instance of a class
+                that can cache API discovery documents. If None, googleapiclient
+                will attempt to choose a default.
             **kwargs (dict): Additional args such as version.
         """
         self._use_cached_http = False
@@ -229,7 +240,8 @@ class BaseRepositoryClient(object):
                 version,
                 self.is_private_api,
                 kwargs.get('developer_key'),
-                kwargs.get('cache_discovery', False),
+                cache_discovery,
+                cache,
                 use_versioned_discovery_doc)
 
     def __repr__(self):

--- a/google/cloud/forseti/common/gcp_api/admin_directory.py
+++ b/google/cloud/forseti/common/gcp_api/admin_directory.py
@@ -49,7 +49,9 @@ class AdminDirectoryRepositoryClient(_base_repository.BaseRepositoryClient):
                  credentials,
                  quota_max_calls=None,
                  quota_period=1.0,
-                 use_rate_limiter=True):
+                 use_rate_limiter=True,
+                 cache_discovery=False,
+                 cache=None):
         """Constructor.
 
         Args:
@@ -61,6 +63,11 @@ class AdminDirectoryRepositoryClient(_base_repository.BaseRepositoryClient):
             quota_period (float): The time period to track requests over.
             use_rate_limiter (bool): Set to false to disable the use of a rate
                 limiter for this service.
+            cache_discovery (bool): When set to true, googleapiclient will cache
+                HTTP requests to API discovery endpoints.
+            cache (googleapiclient.discovery_cache.base.Cache): instance of a
+                class that can cache API discovery documents. If None,
+                googleapiclient will attempt to choose a default.
         """
         if not quota_max_calls:
             use_rate_limiter = False
@@ -74,7 +81,9 @@ class AdminDirectoryRepositoryClient(_base_repository.BaseRepositoryClient):
             credentials=credentials,
             quota_max_calls=quota_max_calls,
             quota_period=quota_period,
-            use_rate_limiter=use_rate_limiter)
+            use_rate_limiter=use_rate_limiter,
+            cache_discovery=cache_discovery,
+            cache=cache)
 
     # Turn off docstrings for properties.
     # pylint: disable=missing-return-doc, missing-return-type-doc
@@ -166,11 +175,16 @@ class AdminDirectoryClient(object):
         max_calls, quota_period = api_helpers.get_ratelimiter_config(
             global_configs, API_NAME)
 
+        cache_discovery = global_configs[
+            'cache_discovery'] if 'cache_discovery' in global_configs else False
+
         self.repository = AdminDirectoryRepositoryClient(
             credentials=credentials,
             quota_max_calls=max_calls,
             quota_period=quota_period,
-            use_rate_limiter=kwargs.get('use_rate_limiter', True))
+            use_rate_limiter=kwargs.get('use_rate_limiter', True),
+            cache_discovery=cache_discovery,
+            cache=global_configs.get('cache'))
 
     def get_group_members(self, group_key):
         """Get all the members for specified groups.

--- a/google/cloud/forseti/common/gcp_api/appengine.py
+++ b/google/cloud/forseti/common/gcp_api/appengine.py
@@ -56,7 +56,9 @@ class AppEngineRepositoryClient(_base_repository.BaseRepositoryClient):
     def __init__(self,
                  quota_max_calls=None,
                  quota_period=1.0,
-                 use_rate_limiter=True):
+                 use_rate_limiter=True,
+                 cache_discovery=False,
+                 cache=None):
         """Constructor.
 
         Args:
@@ -65,6 +67,11 @@ class AppEngineRepositoryClient(_base_repository.BaseRepositoryClient):
             quota_period (float): The time period to track requests over.
             use_rate_limiter (bool): Set to false to disable the use of a rate
                 limiter for this service.
+            cache_discovery (bool): When set to true, googleapiclient will cache
+                HTTP requests to API discovery endpoints.
+            cache (googleapiclient.discovery_cache.base.Cache): instance of a
+                class that can cache API discovery documents. If None,
+                googleapiclient will attempt to choose a default.
         """
         if not quota_max_calls:
             use_rate_limiter = False
@@ -78,7 +85,9 @@ class AppEngineRepositoryClient(_base_repository.BaseRepositoryClient):
             API_NAME, versions=['v1'],
             quota_max_calls=quota_max_calls,
             quota_period=quota_period,
-            use_rate_limiter=use_rate_limiter)
+            use_rate_limiter=use_rate_limiter,
+            cache_discovery=cache_discovery,
+            cache=cache)
 
     # Turn off docstrings for properties.
     # pylint: disable=missing-return-doc, missing-return-type-doc
@@ -262,10 +271,15 @@ class AppEngineClient(object):
         max_calls, quota_period = api_helpers.get_ratelimiter_config(
             global_configs, API_NAME)
 
+        cache_discovery = global_configs[
+            'cache_discovery'] if 'cache_discovery' in global_configs else False
+
         self.repository = AppEngineRepositoryClient(
             quota_max_calls=max_calls,
             quota_period=quota_period,
-            use_rate_limiter=kwargs.get('use_rate_limiter', True))
+            use_rate_limiter=kwargs.get('use_rate_limiter', True),
+            cache_discovery=cache_discovery,
+            cache=global_configs.get('cache'))
 
     def get_app(self, project_id):
         """Gets information about an application.

--- a/google/cloud/forseti/common/gcp_api/bigquery.py
+++ b/google/cloud/forseti/common/gcp_api/bigquery.py
@@ -33,7 +33,9 @@ class BigQueryRepositoryClient(_base_repository.BaseRepositoryClient):
     def __init__(self,
                  quota_max_calls=None,
                  quota_period=100.0,
-                 use_rate_limiter=True):
+                 use_rate_limiter=True,
+                 cache_discovery=False,
+                 cache=None):
         """Constructor.
 
         Args:
@@ -42,6 +44,11 @@ class BigQueryRepositoryClient(_base_repository.BaseRepositoryClient):
             quota_period (float): The time period to track requests over.
             use_rate_limiter (bool): Set to false to disable the use of a rate
                 limiter for this service.
+            cache_discovery (bool): When set to true, googleapiclient will cache
+                HTTP requests to API discovery endpoints.
+            cache (googleapiclient.discovery_cache.base.Cache): instance of a
+                class that can cache API discovery documents. If None,
+                googleapiclient will attempt to choose a default.
         """
         if not quota_max_calls:
             use_rate_limiter = False
@@ -54,7 +61,9 @@ class BigQueryRepositoryClient(_base_repository.BaseRepositoryClient):
             API_NAME, versions=['v2'],
             quota_max_calls=quota_max_calls,
             quota_period=quota_period,
-            use_rate_limiter=use_rate_limiter)
+            use_rate_limiter=use_rate_limiter,
+            cache_discovery=cache_discovery,
+            cache=cache)
 
     # Turn off docstrings for properties.
     # pylint: disable=missing-return-doc, missing-return-type-doc
@@ -144,10 +153,15 @@ class BigQueryClient(object):
         max_calls, quota_period = api_helpers.get_ratelimiter_config(
             global_configs, API_NAME)
 
+        cache_discovery = global_configs[
+            'cache_discovery'] if 'cache_discovery' in global_configs else False
+
         self.repository = BigQueryRepositoryClient(
             quota_max_calls=max_calls,
             quota_period=quota_period,
-            use_rate_limiter=kwargs.get('use_rate_limiter', True))
+            use_rate_limiter=kwargs.get('use_rate_limiter', True),
+            cache_discovery=cache_discovery,
+            cache=global_configs.get('cache'))
 
     def get_bigquery_projectids(self):
         """Request and page through bigquery projectids.

--- a/google/cloud/forseti/common/gcp_api/cloud_resource_manager.py
+++ b/google/cloud/forseti/common/gcp_api/cloud_resource_manager.py
@@ -41,7 +41,7 @@ class CloudResourceManagerRepositoryClient(
                  use_rate_limiter=True,
                  credentials=None,
                  cache_discovery=False,
-cache=None):
+                 cache=None):
         """Constructor.
 
         Args:

--- a/google/cloud/forseti/common/gcp_api/cloud_resource_manager.py
+++ b/google/cloud/forseti/common/gcp_api/cloud_resource_manager.py
@@ -39,7 +39,9 @@ class CloudResourceManagerRepositoryClient(
                  quota_max_calls=None,
                  quota_period=100.0,
                  use_rate_limiter=True,
-                 credentials=None):
+                 credentials=None,
+                 cache_discovery=False,
+cache=None):
         """Constructor.
 
         Args:
@@ -50,6 +52,11 @@ class CloudResourceManagerRepositoryClient(
                 limiter for this service.
             credentials (OAuth2Credentials): Credentials that will be used to
                 authenticate the API calls.
+            cache_discovery (bool): When set to true, googleapiclient will cache
+                HTTP requests to API discovery endpoints.
+            cache (googleapiclient.discovery_cache.base.Cache): instance of a
+                class that can cache API discovery documents. If None,
+                googleapiclient will attempt to choose a default.
         """
         if not quota_max_calls:
             use_rate_limiter = False
@@ -65,7 +72,9 @@ class CloudResourceManagerRepositoryClient(
             quota_max_calls=quota_max_calls,
             quota_period=quota_period,
             use_rate_limiter=use_rate_limiter,
-            credentials=credentials)
+            credentials=credentials,
+            cache_discovery=cache_discovery,
+            cache=cache)
 
     # Turn off docstrings for properties.
     # pylint: disable=missing-return-doc, missing-return-type-doc
@@ -274,11 +283,16 @@ class CloudResourceManagerClient(object):
         max_calls, quota_period = api_helpers.get_ratelimiter_config(
             global_configs, API_NAME)
 
+        cache_discovery = global_configs[
+            'cache_discovery'] if 'cache_discovery' in global_configs else False
+
         self.repository = CloudResourceManagerRepositoryClient(
             quota_max_calls=max_calls,
             quota_period=quota_period,
             use_rate_limiter=kwargs.get('use_rate_limiter', True),
-            credentials=kwargs.get('credentials', None))
+            credentials=kwargs.get('credentials', None),
+            cache_discovery=cache_discovery,
+            cache=global_configs.get('cache'))
 
     def get_project(self, project_id):
         """Get all the projects from organization.

--- a/google/cloud/forseti/common/gcp_api/cloudasset.py
+++ b/google/cloud/forseti/common/gcp_api/cloudasset.py
@@ -35,7 +35,9 @@ class CloudAssetRepositoryClient(_base_repository.BaseRepositoryClient):
     def __init__(self,
                  quota_max_calls=None,
                  quota_period=60.0,
-                 use_rate_limiter=True):
+                 use_rate_limiter=True,
+                 cache_discovery=False,
+cache=None):
         """Constructor.
 
         Args:
@@ -44,6 +46,11 @@ class CloudAssetRepositoryClient(_base_repository.BaseRepositoryClient):
             quota_period (float): The time period to track requests over.
             use_rate_limiter (bool): Set to false to disable the use of a rate
                 limiter for this service.
+            cache_discovery (bool): When set to true, googleapiclient will cache
+                HTTP requests to API discovery endpoints.
+            cache (googleapiclient.discovery_cache.base.Cache): instance of a
+                class that can cache API discovery documents. If None,
+                googleapiclient will attempt to choose a default.
         """
         if not quota_max_calls:
             use_rate_limiter = False
@@ -55,7 +62,9 @@ class CloudAssetRepositoryClient(_base_repository.BaseRepositoryClient):
             API_NAME, versions=['v1'],
             quota_max_calls=quota_max_calls,
             quota_period=quota_period,
-            use_rate_limiter=use_rate_limiter)
+            use_rate_limiter=use_rate_limiter,
+            cache_discovery=cache_discovery,
+            cache=cache)
 
     # Turn off docstrings for properties.
     # pylint: disable=missing-return-doc, missing-return-type-doc
@@ -125,10 +134,15 @@ class CloudAssetClient(object):
         max_calls, quota_period = api_helpers.get_ratelimiter_config(
             global_configs, API_NAME)
 
+        cache_discovery = global_configs[
+            'cache_discovery'] if 'cache_discovery' in global_configs else False
+
         self.repository = CloudAssetRepositoryClient(
             quota_max_calls=max_calls,
             quota_period=quota_period,
-            use_rate_limiter=kwargs.get('use_rate_limiter', True))
+            use_rate_limiter=kwargs.get('use_rate_limiter', True),
+            cache_discovery=cache_discovery,
+            cache=global_configs.get('cache'))
 
     @staticmethod
     def build_gcs_object_output(destination_object):

--- a/google/cloud/forseti/common/gcp_api/cloudasset.py
+++ b/google/cloud/forseti/common/gcp_api/cloudasset.py
@@ -37,7 +37,7 @@ class CloudAssetRepositoryClient(_base_repository.BaseRepositoryClient):
                  quota_period=60.0,
                  use_rate_limiter=True,
                  cache_discovery=False,
-cache=None):
+                 cache=None):
         """Constructor.
 
         Args:

--- a/google/cloud/forseti/common/gcp_api/cloudbilling.py
+++ b/google/cloud/forseti/common/gcp_api/cloudbilling.py
@@ -35,7 +35,7 @@ class CloudBillingRepositoryClient(_base_repository.BaseRepositoryClient):
                  quota_period=60.0,
                  use_rate_limiter=True,
                  cache_discovery=False,
-cache=None):
+                 cache=None):
         """Constructor.
 
         Args:

--- a/google/cloud/forseti/common/gcp_api/cloudbilling.py
+++ b/google/cloud/forseti/common/gcp_api/cloudbilling.py
@@ -33,7 +33,9 @@ class CloudBillingRepositoryClient(_base_repository.BaseRepositoryClient):
     def __init__(self,
                  quota_max_calls=None,
                  quota_period=60.0,
-                 use_rate_limiter=True):
+                 use_rate_limiter=True,
+                 cache_discovery=False,
+cache=None):
         """Constructor.
 
         Args:
@@ -42,6 +44,11 @@ class CloudBillingRepositoryClient(_base_repository.BaseRepositoryClient):
             quota_period (float): The time period to track requests over.
             use_rate_limiter (bool): Set to false to disable the use of a rate
                 limiter for this service.
+            cache_discovery (bool): When set to true, googleapiclient will cache
+                HTTP requests to API discovery endpoints.
+            cache (googleapiclient.discovery_cache.base.Cache): instance of a
+                class that can cache API discovery documents. If None,
+                googleapiclient will attempt to choose a default.
         """
         if not quota_max_calls:
             use_rate_limiter = False
@@ -53,7 +60,9 @@ class CloudBillingRepositoryClient(_base_repository.BaseRepositoryClient):
             API_NAME, versions=['v1'],
             quota_max_calls=quota_max_calls,
             quota_period=quota_period,
-            use_rate_limiter=use_rate_limiter)
+            use_rate_limiter=use_rate_limiter,
+            cache_discovery=cache_discovery,
+            cache=cache)
 
     # Turn off docstrings for properties.
     # pylint: disable=missing-return-doc, missing-return-type-doc
@@ -169,10 +178,15 @@ class CloudBillingClient(object):
         max_calls, quota_period = api_helpers.get_ratelimiter_config(
             global_configs, API_NAME)
 
+        cache_discovery = global_configs[
+            'cache_discovery'] if 'cache_discovery' in global_configs else False
+
         self.repository = CloudBillingRepositoryClient(
             quota_max_calls=max_calls,
             quota_period=quota_period,
-            use_rate_limiter=kwargs.get('use_rate_limiter', True))
+            use_rate_limiter=kwargs.get('use_rate_limiter', True),
+            cache_discovery=cache_discovery,
+            cache=global_configs.get('cache'))
 
     def get_billing_info(self, project_id):
         """Gets the billing information for a project.

--- a/google/cloud/forseti/common/gcp_api/cloudsql.py
+++ b/google/cloud/forseti/common/gcp_api/cloudsql.py
@@ -33,7 +33,9 @@ class CloudSqlRepositoryClient(_base_repository.BaseRepositoryClient):
     def __init__(self,
                  quota_max_calls=None,
                  quota_period=1.0,
-                 use_rate_limiter=True):
+                 use_rate_limiter=True,
+                 cache_discovery=False,
+                 cache=None):
         """Constructor.
 
         Args:
@@ -42,6 +44,11 @@ class CloudSqlRepositoryClient(_base_repository.BaseRepositoryClient):
             quota_period (float): The time period to track requests over.
             use_rate_limiter (bool): Set to false to disable the use of a rate
                 limiter for this service.
+            cache_discovery (bool): When set to true, googleapiclient will cache
+                HTTP requests to API discovery endpoints.
+            cache (googleapiclient.discovery_cache.base.Cache): instance of a
+                class that can cache API discovery documents. If None,
+                googleapiclient will attempt to choose a default.
         """
         if not quota_max_calls:
             use_rate_limiter = False
@@ -52,7 +59,9 @@ class CloudSqlRepositoryClient(_base_repository.BaseRepositoryClient):
             API_NAME, versions=['v1beta4'],
             quota_max_calls=quota_max_calls,
             quota_period=quota_period,
-            use_rate_limiter=use_rate_limiter)
+            use_rate_limiter=use_rate_limiter,
+            cache_discovery=cache_discovery,
+            cache=cache)
 
     # Turn off docstrings for properties.
     # pylint: disable=missing-return-doc, missing-return-type-doc
@@ -94,10 +103,15 @@ class CloudsqlClient(object):
         max_calls, quota_period = api_helpers.get_ratelimiter_config(
             global_configs, API_NAME)
 
+        cache_discovery = global_configs[
+            'cache_discovery'] if 'cache_discovery' in global_configs else False
+
         self.repository = CloudSqlRepositoryClient(
             quota_max_calls=max_calls,
             quota_period=quota_period,
-            use_rate_limiter=kwargs.get('use_rate_limiter', True))
+            use_rate_limiter=kwargs.get('use_rate_limiter', True),
+            cache_discovery=cache_discovery,
+            cache=global_configs.get('cache'))
 
     def get_instances(self, project_id):
         """Gets all CloudSQL instances for a project.

--- a/google/cloud/forseti/common/gcp_api/compute.py
+++ b/google/cloud/forseti/common/gcp_api/compute.py
@@ -181,7 +181,9 @@ class ComputeRepositoryClient(_base_repository.BaseRepositoryClient):
                  quota_max_calls=None,
                  quota_period=100.0,
                  use_rate_limiter=True,
-                 read_only=False):
+                 read_only=False,
+                 cache_discovery=False,
+                 cache=None):
         """Constructor.
 
         Args:
@@ -192,6 +194,11 @@ class ComputeRepositoryClient(_base_repository.BaseRepositoryClient):
                 limiter for this service.
             read_only (bool): When set to true, disables any API calls that
                 would modify a resource within the repository.
+            cache_discovery (bool): When set to true, googleapiclient will cache
+                HTTP requests to API discovery endpoints.
+            cache (googleapiclient.discovery_cache.base.Cache): instance of a
+                class that can cache API discovery documents. If None,
+                googleapiclient will attempt to choose a default.
         """
         if not quota_max_calls:
             use_rate_limiter = False
@@ -217,7 +224,9 @@ class ComputeRepositoryClient(_base_repository.BaseRepositoryClient):
             quota_max_calls=quota_max_calls,
             quota_period=quota_period,
             use_rate_limiter=use_rate_limiter,
-            read_only=read_only)
+            read_only=read_only,
+            cache_discovery=cache_discovery,
+            cache=cache)
 
     # Turn off docstrings for properties.
     # pylint: disable=missing-return-doc, missing-return-type-doc
@@ -704,11 +713,16 @@ class ComputeClient(object):
         read_only = (kwargs.get('read_only', False) or
                      kwargs.get('dry_run', False))
 
+        cache_discovery = global_configs[
+            'cache_discovery'] if 'cache_discovery' in global_configs else False
+
         self.repository = ComputeRepositoryClient(
             quota_max_calls=max_calls,
             quota_period=quota_period,
             read_only=read_only,
-            use_rate_limiter=kwargs.get('use_rate_limiter', True))
+            use_rate_limiter=kwargs.get('use_rate_limiter', True),
+            cache_discovery=cache_discovery,
+            cache=global_configs.get('cache'))
 
     def get_backend_services(self, project_id):
         """Get the backend services for a project.

--- a/google/cloud/forseti/common/gcp_api/container.py
+++ b/google/cloud/forseti/common/gcp_api/container.py
@@ -33,7 +33,9 @@ class ContainerRepositoryClient(_base_repository.BaseRepositoryClient):
     def __init__(self,
                  quota_max_calls=None,
                  quota_period=100.0,
-                 use_rate_limiter=True):
+                 use_rate_limiter=True,
+                 cache_discovery=False,
+cache=None):
         """Constructor.
 
         Args:
@@ -42,6 +44,11 @@ class ContainerRepositoryClient(_base_repository.BaseRepositoryClient):
             quota_period (float): The time period to track requests over.
             use_rate_limiter (bool): Set to false to disable the use of a rate
                 limiter for this service.
+            cache_discovery (bool): When set to true, googleapiclient will cache
+                HTTP requests to API discovery endpoints.
+            cache (googleapiclient.discovery_cache.base.Cache): instance of a
+                class that can cache API discovery documents. If None,
+                googleapiclient will attempt to choose a default.
         """
         if not quota_max_calls:
             use_rate_limiter = False
@@ -54,7 +61,9 @@ class ContainerRepositoryClient(_base_repository.BaseRepositoryClient):
             API_NAME, versions=['v1', 'v1beta1'],
             quota_max_calls=quota_max_calls,
             quota_period=quota_period,
-            use_rate_limiter=use_rate_limiter)
+            use_rate_limiter=use_rate_limiter,
+            cache_discovery=cache_discovery,
+            cache=cache)
 
     # Turn off docstrings for properties.
     # pylint: disable=missing-return-doc, missing-return-type-doc
@@ -199,10 +208,15 @@ class ContainerClient(object):
         max_calls, quota_period = api_helpers.get_ratelimiter_config(
             global_configs, API_NAME)
 
+        cache_discovery = global_configs[
+            'cache_discovery'] if 'cache_discovery' in global_configs else False
+
         self.repository = ContainerRepositoryClient(
             quota_max_calls=max_calls,
             quota_period=quota_period,
-            use_rate_limiter=kwargs.get('use_rate_limiter', True))
+            use_rate_limiter=kwargs.get('use_rate_limiter', True),
+            cache_discovery=cache_discovery,
+            cache=global_configs.get('cache'))
 
     def get_serverconfig(self, project_id, zone=None, location=None):
         """Gets the serverconfig for a project and zone or location.

--- a/google/cloud/forseti/common/gcp_api/container.py
+++ b/google/cloud/forseti/common/gcp_api/container.py
@@ -35,7 +35,7 @@ class ContainerRepositoryClient(_base_repository.BaseRepositoryClient):
                  quota_period=100.0,
                  use_rate_limiter=True,
                  cache_discovery=False,
-cache=None):
+                 cache=None):
         """Constructor.
 
         Args:

--- a/google/cloud/forseti/common/gcp_api/groups_settings.py
+++ b/google/cloud/forseti/common/gcp_api/groups_settings.py
@@ -48,7 +48,9 @@ class GroupsSettingsRepositoryClient(_base_repository.BaseRepositoryClient):
                  credentials,
                  quota_max_calls=None,
                  quota_period=1.0,
-                 use_rate_limiter=True):
+                 use_rate_limiter=True,
+                 cache_discovery=False,
+                 cache=None):
         """Constructor.
 
         Args:
@@ -60,6 +62,11 @@ class GroupsSettingsRepositoryClient(_base_repository.BaseRepositoryClient):
             quota_period (float): The time period to track requests over.
             use_rate_limiter (bool): Set to false to disable the use of a rate
                 limiter for this service.
+            cache_discovery (bool): When set to true, googleapiclient will cache
+                HTTP requests to API discovery endpoints.
+            cache (googleapiclient.discovery_cache.base.Cache): instance of a
+                class that can cache API discovery documents. If None,
+                googleapiclient will attempt to choose a default.
         """
         if not quota_max_calls:
             use_rate_limiter = False
@@ -71,7 +78,9 @@ class GroupsSettingsRepositoryClient(_base_repository.BaseRepositoryClient):
             credentials=credentials,
             quota_max_calls=quota_max_calls,
             quota_period=quota_period,
-            use_rate_limiter=use_rate_limiter)
+            use_rate_limiter=use_rate_limiter,
+            cache_discovery=cache_discovery,
+            cache=cache)
 
     # Turn off docstrings for properties.
     # pylint: disable=missing-return-doc, missing-return-type-doc
@@ -117,11 +126,16 @@ class GroupsSettingsClient(object):
         max_calls, quota_period = api_helpers.get_ratelimiter_config(
             global_configs, API_NAME)
 
+        cache_discovery = global_configs[
+            'cache_discovery'] if 'cache_discovery' in global_configs else False
+
         self.repository = GroupsSettingsRepositoryClient(
             credentials=credentials,
             quota_max_calls=max_calls,
             quota_period=quota_period,
-            use_rate_limiter=kwargs.get('use_rate_limiter', True))
+            use_rate_limiter=kwargs.get('use_rate_limiter', True),
+            cache_discovery=cache_discovery,
+            cache=global_configs.get('cache'))
 
     def get_groups_settings(self, group_email):
         """Get the group settings for a given group.

--- a/google/cloud/forseti/common/gcp_api/iam.py
+++ b/google/cloud/forseti/common/gcp_api/iam.py
@@ -36,7 +36,9 @@ class IamRepositoryClient(_base_repository.BaseRepositoryClient):
     def __init__(self,
                  quota_max_calls=None,
                  quota_period=1.0,
-                 use_rate_limiter=True):
+                 use_rate_limiter=True,
+                 cache_discovery=False,
+                 cache=None):
         """Constructor.
 
         Args:
@@ -45,6 +47,11 @@ class IamRepositoryClient(_base_repository.BaseRepositoryClient):
             quota_period (float): The time period to limit the requests within.
             use_rate_limiter (bool): Set to false to disable the use of a rate
                 limiter for this service.
+            cache_discovery (bool): When set to true, googleapiclient will cache
+                HTTP requests to API discovery endpoints.
+            cache (googleapiclient.discovery_cache.base.Cache): instance of a
+                class that can cache API discovery documents. If None,
+                googleapiclient will attempt to choose a default.
         """
         if not quota_max_calls:
             use_rate_limiter = False
@@ -59,7 +66,9 @@ class IamRepositoryClient(_base_repository.BaseRepositoryClient):
             API_NAME, versions=['v1'],
             quota_max_calls=quota_max_calls,
             quota_period=quota_period,
-            use_rate_limiter=use_rate_limiter)
+            use_rate_limiter=use_rate_limiter,
+            cache_discovery=cache_discovery,
+            cache=cache)
 
     # Turn off docstrings for properties.
     # pylint: disable=missing-return-doc, missing-return-type-doc
@@ -268,10 +277,15 @@ class IAMClient(object):
         max_calls, quota_period = api_helpers.get_ratelimiter_config(
             global_configs, API_NAME)
 
+        cache_discovery = global_configs[
+            'cache_discovery'] if 'cache_discovery' in global_configs else False
+
         self.repository = IamRepositoryClient(
             quota_max_calls=max_calls,
             quota_period=quota_period,
-            use_rate_limiter=kwargs.get('use_rate_limiter', True))
+            use_rate_limiter=kwargs.get('use_rate_limiter', True),
+            cache_discovery=cache_discovery,
+            cache=global_configs.get('cache'))
 
     def get_curated_roles(self, parent=None):
         """Get information about organization roles

--- a/google/cloud/forseti/common/gcp_api/securitycenter.py
+++ b/google/cloud/forseti/common/gcp_api/securitycenter.py
@@ -34,7 +34,9 @@ class SecurityCenterRepositoryClient(_base_repository.BaseRepositoryClient):
     def __init__(self,
                  quota_max_calls=None,
                  quota_period=1.0,
-                 use_rate_limiter=True):
+                 use_rate_limiter=True,
+                 cache_discovery=False,
+                 cache=None):
         """Constructor.
         Args:
             quota_max_calls (int): Allowed requests per <quota_period> for the
@@ -42,6 +44,11 @@ class SecurityCenterRepositoryClient(_base_repository.BaseRepositoryClient):
             quota_period (float): The time period to track requests over.
             use_rate_limiter (bool): Set to false to disable the use of a rate
                 limiter for this service.
+            cache_discovery (bool): When set to true, googleapiclient will cache
+                HTTP requests to API discovery endpoints.
+            cache (googleapiclient.discovery_cache.base.Cache): instance of a
+                class that can cache API discovery documents. If None,
+                googleapiclient will attempt to choose a default.
         """
         LOGGER.debug('Initializing SecurityCenterRepositoryClient')
         if not quota_max_calls:
@@ -103,19 +110,24 @@ class SecurityCenterClient(object):
     https://cloud.google.com/security-command-center/docs/reference/rest
     """
 
-    def __init__(self, api_quota):
+    def __init__(self, global_configs):
         """Initialize.
 
         Args:
-            api_quota (dict): API quota configs
+            global_configs (dict): Global configurations.
         """
 
         max_calls, quota_period = api_helpers.get_ratelimiter_config(
-            api_quota, API_NAME)
+            global_configs, API_NAME)
+
+        cache_discovery = global_configs[
+            'cache_discovery'] if 'cache_discovery' in global_configs else False
 
         self.repository = SecurityCenterRepositoryClient(
             quota_max_calls=max_calls,
-            quota_period=quota_period)
+            quota_period=quota_period,
+            cache_discovery=cache_discovery,
+            cache=global_configs.get('cache'))
 
     def create_finding(self, finding, source_id=None, finding_id=None):
         """Creates a finding in CSCC.

--- a/google/cloud/forseti/common/gcp_api/servicemanagement.py
+++ b/google/cloud/forseti/common/gcp_api/servicemanagement.py
@@ -33,7 +33,9 @@ class ServiceManagementRepositoryClient(_base_repository.BaseRepositoryClient):
     def __init__(self,
                  quota_max_calls=None,
                  quota_period=100.0,
-                 use_rate_limiter=True):
+                 use_rate_limiter=True,
+                 cache_discovery=False,
+                 cache=None):
         """Constructor.
 
         Args:
@@ -42,6 +44,11 @@ class ServiceManagementRepositoryClient(_base_repository.BaseRepositoryClient):
             quota_period (float): The time period to track requests over.
             use_rate_limiter (bool): Set to false to disable the use of a rate
                 limiter for this service.
+            cache_discovery (bool): When set to true, googleapiclient will cache
+                HTTP requests to API discovery endpoints.
+            cache (googleapiclient.discovery_cache.base.Cache): instance of a
+                class that can cache API discovery documents. If None,
+                googleapiclient will attempt to choose a default.
         """
         if not quota_max_calls:
             use_rate_limiter = False
@@ -52,7 +59,9 @@ class ServiceManagementRepositoryClient(_base_repository.BaseRepositoryClient):
             API_NAME, versions=['v1'],
             quota_max_calls=quota_max_calls,
             quota_period=quota_period,
-            use_rate_limiter=use_rate_limiter)
+            use_rate_limiter=use_rate_limiter,
+            cache_discovery=cache_discovery,
+            cache=cache)
 
     # Turn off docstrings for properties.
     # pylint: disable=missing-return-doc, missing-return-type-doc
@@ -166,10 +175,15 @@ class ServiceManagementClient(object):
         max_calls, quota_period = api_helpers.get_ratelimiter_config(
             global_configs, API_NAME)
 
+        cache_discovery = global_configs[
+            'cache_discovery'] if 'cache_discovery' in global_configs else False
+
         self.repository = ServiceManagementRepositoryClient(
             quota_max_calls=max_calls,
             quota_period=quota_period,
-            use_rate_limiter=kwargs.get('use_rate_limiter', True))
+            use_rate_limiter=kwargs.get('use_rate_limiter', True),
+            cache_discovery=cache_discovery,
+            cache=global_configs.get('cache'))
 
     def get_all_apis(self):
         """Gets all APIs that can be enabled (based on caller's permissions).

--- a/google/cloud/forseti/common/gcp_api/serviceusage.py
+++ b/google/cloud/forseti/common/gcp_api/serviceusage.py
@@ -33,7 +33,9 @@ class ServiceUsageRepositoryClient(_base_repository.BaseRepositoryClient):
     def __init__(self,
                  quota_max_calls=None,
                  quota_period=100.0,
-                 use_rate_limiter=True):
+                 use_rate_limiter=True,
+                 cache_discovery=False,
+                 cache=None):
         """Constructor.
 
         Args:
@@ -53,8 +55,9 @@ class ServiceUsageRepositoryClient(_base_repository.BaseRepositoryClient):
             API_NAME, versions=['v1'],
             quota_max_calls=quota_max_calls,
             quota_period=quota_period,
-            use_rate_limiter=use_rate_limiter
-        )
+            use_rate_limiter=use_rate_limiter,
+            cache_discover=cache_discovery,
+            cache=cache)
 
     # Turn off docstrings for properties.
     # pylint: disable=missing-return-doc, missing-return-type-doc
@@ -118,10 +121,15 @@ class ServiceUsageClient(object):
         max_calls, quota_period = api_helpers.get_ratelimiter_config(
             global_configs, API_NAME)
 
+        cache_discovery = global_configs[
+            'cache_discovery'] if 'cache_discovery' in global_configs else False
+
         self.repository = ServiceUsageRepositoryClient(
             quota_max_calls=max_calls,
             quota_period=quota_period,
-            use_rate_limiter=kwargs.get('use_rate_limiter', True))
+            use_rate_limiter=kwargs.get('use_rate_limiter', True),
+            cache_discovery=cache_discovery,
+            cache=global_configs.get('cache'))
 
     def get_enabled_apis(self, project_id):
         """Gets the enabled APIs for a project.

--- a/google/cloud/forseti/common/gcp_api/stackdriver_logging.py
+++ b/google/cloud/forseti/common/gcp_api/stackdriver_logging.py
@@ -33,7 +33,9 @@ class StackdriverLoggingRepositoryClient(_base_repository.BaseRepositoryClient):
     def __init__(self,
                  quota_max_calls=None,
                  quota_period=1.0,
-                 use_rate_limiter=True):
+                 use_rate_limiter=True,
+                 cache_discovery=False,
+                 cache=None):
         """Constructor.
 
         Args:
@@ -42,6 +44,11 @@ class StackdriverLoggingRepositoryClient(_base_repository.BaseRepositoryClient):
             quota_period (float): The time period to track requests over.
             use_rate_limiter (bool): Set to false to disable the use of a rate
                 limiter for this service.
+            cache_discovery (bool): When set to true, googleapiclient will cache
+                HTTP requests to API discovery endpoints.
+            cache (googleapiclient.discovery_cache.base.Cache): instance of a
+                class that can cache API discovery documents. If None,
+                googleapiclient will attempt to choose a default.
         """
         if not quota_max_calls:
             use_rate_limiter = False
@@ -55,7 +62,9 @@ class StackdriverLoggingRepositoryClient(_base_repository.BaseRepositoryClient):
             API_NAME, versions=['v2'],
             quota_max_calls=quota_max_calls,
             quota_period=quota_period,
-            use_rate_limiter=use_rate_limiter)
+            use_rate_limiter=use_rate_limiter,
+            cache_discovery=cache_discovery,
+            cache=cache)
 
     # Turn off docstrings for properties.
     # pylint: disable=missing-return-doc, missing-return-type-doc
@@ -218,10 +227,15 @@ class StackdriverLoggingClient(object):
         max_calls, quota_period = api_helpers.get_ratelimiter_config(
             global_configs, API_NAME)
 
+        cache_discovery = global_configs[
+            'cache_discovery'] if 'cache_discovery' in global_configs else False
+
         self.repository = StackdriverLoggingRepositoryClient(
             quota_max_calls=max_calls,
             quota_period=quota_period,
-            use_rate_limiter=kwargs.get('use_rate_limiter', True))
+            use_rate_limiter=kwargs.get('use_rate_limiter', True),
+            cache_discovery=cache_discovery,
+            cache=global_configs.get('cache'))
 
     def get_organization_sinks(self, org_id):
         """Get information about organization sinks.

--- a/google/cloud/forseti/common/util/file_loader.py
+++ b/google/cloud/forseti/common/util/file_loader.py
@@ -60,7 +60,7 @@ def copy_file_from_gcs(file_path, output_path=None, storage_client=None):
         str: The output_path the file was copied to.
     """
     if not storage_client:
-        storage_client = storage.StorageClient()
+        storage_client = storage.StorageClient({})
 
     if not output_path:
         tmp_file, output_path = tempfile.mkstemp()
@@ -171,7 +171,7 @@ def _read_file_from_gcs(file_path, storage_client=None):
         dict: The parsed dict from the loaded file.
     """
     if not storage_client:
-        storage_client = storage.StorageClient()
+        storage_client = storage.StorageClient({})
 
     file_content = storage_client.get_text_file(full_bucket_path=file_path)
 

--- a/google/cloud/forseti/common/util/file_uploader.py
+++ b/google/cloud/forseti/common/util/file_uploader.py
@@ -37,7 +37,7 @@ def upload_json(data, gcs_upload_path):
         with tempfile.NamedTemporaryFile() as tmp_data:
             tmp_data.write(parser.json_stringify(data).encode())
             tmp_data.flush()
-            storage_client = StorageClient()
+            storage_client = StorageClient({})
             storage_client.put_text_file(tmp_data.name, gcs_upload_path)
     except Exception:  # pylint: disable=broad-except
         LOGGER.exception('Unable to upload json document to bucket %s:\n%s',
@@ -55,7 +55,7 @@ def upload_csv(resource_name, data, gcs_upload_path):
     try:
         with csv_writer.write_csv(resource_name, data, True) as csv_file:
             LOGGER.info('CSV filename: %s', csv_file.name)
-            storage_client = StorageClient()
+            storage_client = StorageClient({})
             storage_client.put_text_file(csv_file.name, gcs_upload_path)
     except Exception:  # pylint: disable=broad-except
         LOGGER.exception('Unable to upload csv document to bucket %s:\n%s\n%s',

--- a/google/cloud/forseti/services/inventory/base/cloudasset.py
+++ b/google/cloud/forseti/services/inventory/base/cloudasset.py
@@ -160,7 +160,7 @@ def load_cloudasset_data(engine, config, inventory_index_id):
     """
     cai_gcs_dump_paths = config.get_cai_dump_file_paths()
 
-    storage_client = storage.StorageClient()
+    storage_client = storage.StorageClient({})
     imported_assets = 0
 
     if not cai_gcs_dump_paths:


### PR DESCRIPTION
Currently `BaseRepositoryClient` accepts the `cache_discovery` parameter, but it's defaulted to False with no way for a user of Forseti to change it.

We'd like to set it to True so that we don't have to make an HTTP request for discovery every time a new API client is created.

The new `cache` parameter is provided so that callers can provide their own cache implementation for use by googleapiclient. This is needed because googleapiclient relies by default on a cache provided by the (deprecated) oauth2client lib! We want to do API discovery caching without adding a dependency on a deprecated lib.

Thanks for opening a Pull Request!

Here's a handy checklist to ensure your PR goes smoothly.

- [x] I signed Google's [Contributor License Agreement](https://opensource.google.com/docs/cla/)
- [x] My code conforms to Google's [python style](https://google.github.io/styleguide/pyguide.html).
- [x] My PR at a minimum doesn't decrease unit-test coverage (if applicable).
- [x] My PR has been functionally tested.
- [x] All of the [tests](https://forsetisecurity.org/docs/latest/develop/dev/testing.html) pass.
- [ ] I have submitted a corresponding PR for documentation in the `forsetisecurity.org-dev branch` and included this on this PR (if applicable).
- [ ] My documentation has been functionally tested and used (if applicable).
- [ ] I have submitted a corresponding PR in the [Forseti Terraform module](https://github.com/forseti-security/terraform-google-forseti) (if applicable).

These guidelines and more can be found in our [contributing guidelines](https://github.com/forseti-security/forseti-security/blob/dev/.github/CONTRIBUTING.md).
